### PR TITLE
A few c2rust dependency fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 
 # c2rust deps
 RUN apt-get install -y \
-    build-essential llvm clang libclang-dev cmake \
+    build-essential llvm llvm-dev clang libclang-dev cmake \
     libssl-dev pkg-config python3 git
 
 # Install c2rust


### PR DESCRIPTION
We've switched from `rustfmt-preview` to `rustfmt` (the former is pretty outdated), and also, `llvm-dev` is sometimes needed (depending on the version), although it's usually included with `llvm`, `clang`, and `libclang-dev`.