### PR TITLE
install `hayroll` and run `hayroll` wrapper instead of `c2rust`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM docker.io/rust:bookworm
+# Need gcc-13 for hayroll.
+# Debian bookworm (12) only has gcc-12.
+# Debian trixie (13) has gcc-13.
+FROM docker.io/rust:trixie
 
-RUN rustup default 1.87.0
+# rust-analyzer (required by hayroll)'s deps require Rust 1.89
+RUN rustup default 1.90.0
 
 RUN apt-get update
 
@@ -13,6 +17,12 @@ RUN apt-get install -y \
 RUN cargo install \
     --locked \
     c2rust
+
+# Install hayroll
+RUN git clone https://github.com/UW-HARVEST/Hayroll \
+    && cd Hayroll \
+    && ./prerequisites.bash --no-sudo --llvm-version 18 \
+    && ./build.bash
 
 # Install the default toolchain for c2rust transpiled projects
 RUN rustup toolchain add \

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -140,12 +140,12 @@ class Workflow:
             sb.checkout_file(COMPILE_COMMANDS_PATH, n_cc)
             sb.checkout(n_c_code)
 
-            # Run c2rust-transpile
+            # Run c2rust-transpile through hayroll.
             c2rust_cmd = [
-                    'c2rust-transpile',
+                    'hayroll',
+                    'transpile',
                     sb.join(COMPILE_COMMANDS_PATH),
                     '--output-dir', sb.join(output_path),
-                    '--emit-build-files',
                     ]
             if cfg.transpile.bin_main is not None:
                 c2rust_cmd.extend((


### PR DESCRIPTION
I haven't tested this yet, but this should build in docker.  Getting all of the dependencies of hayroll to work was tricky, so I needed to update a bunch of other stuff.  Also, hayroll is less complete, so this will transpile successfully on fewer projects than just c2rust, so we may want to keep this in a branch.  I'm not sure how exactly we want to integrate hayroll for its conditional compilation support, but this should be a start.