### PR TITLE
ci: run the `docker build`s from the `README.md`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker-build-crisp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build tractor-crisp
+        run: docker build . -t tractor-crisp
+
+  docker-build-crisp-user:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build tractor-crisp-user
+        run: docker build . -f Dockerfile.work -t tractor-crisp-user


### PR DESCRIPTION
Nothing is cached yet, but it'll be helpful to at least have something in CI to start with. The Docker containers aren't run at all yet either.