### PR TITLE
docker: remove unused toolchain components for transpiled code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN apt-get install -y \
 
 # Install the toolchain used to build c2rust
 RUN rustup toolchain add \
-    -c rustfmt,rustc-dev,rust-src,miri,rust-analyzer \
+    --component rustfmt,rustc-dev \
     nightly-2022-08-08
 
 # Install the default toolchain for c2rust and hayroll transpiled projects
 RUN rustup toolchain add \
-    -c rustfmt,rustc-dev,rust-src,miri,rust-analyzer \
+    --component rustfmt \
     nightly-2023-04-15
 
 # Update crates.io index for future use.  There's no dedicated command to force

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -21,12 +21,12 @@ RUN apt-get install -y \
 
 # Install the toolchain used to build c2rust
 RUN rustup toolchain add \
-    -c rustfmt,rustc-dev,rust-src,miri,rust-analyzer \
+    --component rustfmt,rustc-dev \
     nightly-2022-08-08
 
 # Install the default toolchain for c2rust and hayroll transpiled projects
 RUN rustup toolchain add \
-    -c rustfmt,rustc-dev,rust-src,miri,rust-analyzer \
+    --component rustfmt \
     nightly-2023-04-15
 
 # Update crates.io index for future use.  There's no dedicated command to force


### PR DESCRIPTION
Only `rustfmt` is needed.  See https://github.com/immunant/c2rust/blob/800158256678372b8abe15e471e78fc62d6fefdd/c2rust-transpile/src/build_files/generated-rust-toolchain.toml#L3.