### PR TITLE
workflow: fix missing `import sys`

### DIFF
--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 import os
 import subprocess
+import sys
 from typing import Any
 
 from . import analysis, llm


### PR DESCRIPTION
#13 added a mention of `sys.stderr`, but didn't add the necessary import.