### PR TITLE
crisp: create `/root/work` before `.put_archive()`ing to `/root/work`

### DIFF
--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -39,6 +39,7 @@ class WorkContainer:
             #self.container.remove(v=True)
 
     def _checkout_tar_file(self, tar_bytes):
+        self.container.exec_run("mkdir -p /root/work")
         self.container.put_archive('/root/work/', tar_bytes)
 
     def checkout(self, n_tree):


### PR DESCRIPTION
`Container.put_archive` requires the path to exist already, but `Dockerfile.work` does not create `/root/work/`.

To test, I ran this:

```sh
uv venv venv/
uv sync
docker build . -f Dockerfile.work -t tractor-crisp-user
export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock # running rootless docker since I don't have sudo
uv run scripts/test_eval_20250917.py ~/work/Test-Corpus/Public-Tests/B01_organic/colourblind_lib/
```