### PR TITLE
mvir: fix `Metadata`

### DIFF
--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -158,13 +158,13 @@ def _dataclass_to_cbor(x):
     implementation for use in classes that have `dataclass`-style typed
     fields.'''
     cls = x.__class__
-    field_tys = _metadata_field_types(cls)
+    field_tys = typing.get_type_hints(cls)
     values = tuple(getattr(x, name) for name in field_tys.keys())
     return to_cbor(values)
 
 @classmethod
 def _dataclass_from_cbor(cls, raw):
-    field_tys = _metadata_field_types(cls)
+    field_tys = typing.get_type_hints(cls)
     expect_ty = tuple[*field_tys.values()]
     values = from_cbor(expect_ty, raw)
     return cls(*values)


### PR DESCRIPTION
Oops.  I had a mistake in the `Metadata` implementation.  This should fix it, and I tested it more thoroughly now.

Tested on

```sh
LLM_SAFETY_TRIES=0 ./scripts/test_eval_20250917.py ~/work/Test-Corpus/Public-Tests/B01_organic/colourblind_lib/
```