### PR TITLE
docker: update `c2rust` to include `c2rust-refactor` fix for casts from non-unit to unit types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN uv python install
 RUN cd /opt \
     && git clone https://github.com/immunant/c2rust --depth 1 \
     && cd c2rust \
-    && git fetch --depth 1 origin 4b400b4aab375836a0563d2d0762e60a5fcf1c1a \
+    && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
     && git checkout FETCH_HEAD
 RUN cd /opt/c2rust \
     && uv venv \

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -47,7 +47,7 @@ RUN uv python install
 RUN cd /opt \
     && git clone https://github.com/immunant/c2rust --depth 1 \
     && cd c2rust \
-    && git fetch --depth 1 origin 4b400b4aab375836a0563d2d0762e60a5fcf1c1a \
+    && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
     && git checkout FETCH_HEAD
 RUN cd /opt/c2rust \
     && uv venv \


### PR DESCRIPTION
* This adds https://github.com/immunant/c2rust/pull/1567.