### PR TITLE
docker: move `libz3.so` so it's accessible with `sudo` so `hayroll` can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ COPY .cargo/config.toml $CARGO_HOME/config.toml
 ENV XDG_BIN_HOME=/usr/local/bin
 # `uv` installs data (like libraries) in `$XDG_DATA_HOME/uv`.
 ENV XDG_DATA_HOME=/usr/local
+# We pin the `uv` version because using directories not owned by the user
+# may not be supported by `uv` in the future,
+# but it works in the current version.
 RUN curl -LsSf https://astral.sh/uv/0.9.29/install.sh | sh
 RUN uv python install
 

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -41,6 +41,9 @@ COPY .cargo/config.toml $CARGO_HOME/config.toml
 ENV XDG_BIN_HOME=/usr/local/bin
 # `uv` installs data (like libraries) in `$XDG_DATA_HOME/uv`.
 ENV XDG_DATA_HOME=/usr/local
+# We pin the `uv` version because using directories not owned by the user
+# may not be supported by `uv` in the future,
+# but it works in the current version.
 RUN curl -LsSf https://astral.sh/uv/0.9.29/install.sh | sh
 RUN uv python install
 


### PR DESCRIPTION
* Fixes #49.

`hayroll` depends on `libz3.so`, but since it uses `uv` to install `libz3`, it's placed under `/root/.local/share/uv/` since `$HOME` is `/root`. `/root` is obviously not accessible to other users with `sudo`, so set `XDG_DATA_HOME=/usr/local` so that `uv` uses the accessible `/usr/local/uv` instead. Moreover, set `XDG_BIN_HOME=/usr/local/bin` so that `uv` itself and other binaries `uv` installs are accessible as well.