### PR TITLE
docker: update `hayroll` to include `--binary` support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN uv python install
 
 # Install c2rust
 RUN cd /opt \
-    && git clone https://github.com/immunant/c2rust --depth 1 \
+    && git clone --depth 1 https://github.com/immunant/c2rust \
     && cd c2rust \
     && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
     && git checkout FETCH_HEAD
@@ -54,9 +54,10 @@ RUN cd /opt/c2rust && cargo install --locked --path c2rust-refactor
 # right version.
 RUN mkdir -p /opt/hayroll \
     && cd /opt/hayroll \
-    && git clone https://github.com/UW-HARVEST/Hayroll \
+    && git clone --depth 1 https://github.com/UW-HARVEST/Hayroll \
     && cd Hayroll \
-    && git checkout fed1474939fe0dd161ad30413d5225252a8fe471
+    && git fetch --depth 1 origin fed1474939fe0dd161ad30413d5225252a8fe471 \
+    && git checkout FETCH_HEAD
 # Trixie's `llvm` defaults to 19 and so that's what `c2rust` is using, too.
 RUN cd /opt/hayroll/Hayroll \
     && ./prerequisites.bash --no-sudo --llvm-version 19

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -41,7 +41,7 @@ RUN uv python install
 
 # Install c2rust
 RUN cd /opt \
-    && git clone https://github.com/immunant/c2rust --depth 1 \
+    && git clone --depth 1 https://github.com/immunant/c2rust \
     && cd c2rust \
     && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
     && git checkout FETCH_HEAD
@@ -59,9 +59,10 @@ RUN cd /opt/c2rust && cargo install --locked --path c2rust-refactor
 # right version.
 RUN mkdir -p /opt/hayroll \
     && cd /opt/hayroll \
-    && git clone https://github.com/UW-HARVEST/Hayroll \
+    && git clone --depth 1 https://github.com/UW-HARVEST/Hayroll \
     && cd Hayroll \
-    && git checkout fed1474939fe0dd161ad30413d5225252a8fe471
+    && git fetch --depth 1 origin fed1474939fe0dd161ad30413d5225252a8fe471 \
+    && git checkout FETCH_HEAD
 # Trixie's `llvm` defaults to 19 and so that's what `c2rust` is using, too.
 RUN cd /opt/hayroll/Hayroll \
     && ./prerequisites.bash --no-sudo --llvm-version 19


### PR DESCRIPTION
* Fixes #51.
* Added in https://github.com/UW-HARVEST/Hayroll/commit/3c21e3b3c14b9fc072f9e0cf3ea27faed7de0daf.