### PR TITLE
workflow: print logs as a `str`, not `bytes`

### DIFF
--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -237,7 +237,7 @@ class Workflow:
 
         if exit_code != 0:
             # TODO: proper log parsing
-            print(repr(logs))
+            print(logs.decode())
         print('c2rust process %s with code %d:\n%s' % (
             'succeeded' if n_op.exit_code == 0 else 'failed', n_op.exit_code, n_op.cmd))
 


### PR DESCRIPTION
All of the other places, we generally log `.body_str()`, but here we print the output as `bytes`, which makes it harder to read.