### PR TITLE
docker: update `c2rust` to `v0.22.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN uv python install
 RUN cd /opt \
     && git clone --depth 1 https://github.com/immunant/c2rust \
     && cd c2rust \
-    && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
+    && git fetch --depth 1 origin 1b2818697e2322b99ca0b78d8e23e8c965451343 \
     && git checkout FETCH_HEAD
 RUN cd /opt/c2rust \
     && uv venv \

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -51,7 +51,7 @@ RUN uv python install
 RUN cd /opt \
     && git clone --depth 1 https://github.com/immunant/c2rust \
     && cd c2rust \
-    && git fetch --depth 1 origin e8d55cdc311912889ea82db6979c3709c7c8c4b2 \
+    && git fetch --depth 1 origin 1b2818697e2322b99ca0b78d8e23e8c965451343 \
     && git checkout FETCH_HEAD
 RUN cd /opt/c2rust \
     && uv venv \

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -207,8 +207,6 @@ class Workflow:
                     "--output-dir",
                     sb.join(output_path),
                     "--emit-build-files",
-                    "--c2rust-dir",
-                    "/opt/c2rust/",
                 ]
                 if src_loc_annotations:
                     c2rust_cmd += [


### PR DESCRIPTION
* Fixes #46.

This fixes the mismatch between `c2rust-bitfields` and the published `v0.21.0` version, so we don't need to use `--c2rust-dir` anymore.  `--c2rust-dir` still keeps things in sync going forward, but it removes portability out of the container.  Thus, this fixes #46.