### PR TITLE
docker: trim image size by avoiding caching temporary build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,14 @@ COPY deps/hayroll /opt/hayroll/hayroll
 # Trixie's `llvm` defaults to 19 and so that's what `c2rust` is using, too.
 RUN cd /opt/hayroll/hayroll \
     && ./prerequisites.bash --no-sudo --llvm-version 19 \
-    && rm -rf ../z3/build/src/
+    && rm -rf ../z3/build/src/ \
+    && mv ../Maki/build/lib/libcpp2c.so . \
+    && mv ../Maki/build/bin/cpp2c . \
+    && rm -rf ../Maki/build/ \
+    && mkdir -p ../Maki/build/lib \
+    && mkdir -p ../Maki/build/bin \
+    && mv libcpp2c.so ../Maki/build/lib/ \
+    && mv cpp2c ../Maki/build/bin/
 RUN cd /opt/hayroll/hayroll \
     && ./build.bash --release \
     && rm -rf $CARGO_TARGET_DIR \

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -71,7 +71,14 @@ COPY deps/hayroll /opt/hayroll/hayroll
 # Trixie's `llvm` defaults to 19 and so that's what `c2rust` is using, too.
 RUN cd /opt/hayroll/hayroll \
     && ./prerequisites.bash --no-sudo --llvm-version 19 \
-    && rm -rf ../z3/build/src/
+    && rm -rf ../z3/build/src/ \
+    && mv ../Maki/build/lib/libcpp2c.so . \
+    && mv ../Maki/build/bin/cpp2c . \
+    && rm -rf ../Maki/build/ \
+    && mkdir -p ../Maki/build/lib \
+    && mkdir -p ../Maki/build/bin \
+    && mv libcpp2c.so ../Maki/build/lib/ \
+    && mv cpp2c ../Maki/build/bin/
 RUN cd /opt/hayroll/hayroll \
     && ./build.bash --release \
     && rm -rf $CARGO_TARGET_DIR \


### PR DESCRIPTION
CI kept running out of storage when building/loading the Docker images, so this cuts ~6 GB off the image size by avoiding caching (by deleting it during that step) temporary build artifacts like `target/` directories.  For our normal `cargo install`s, those use temporary directories, so it's unclear which to delete, so we set `CARGO_TARGET_DIR` and delete that after, as well as the cargo registry.  For Hayroll, it's a bit trickier, since the build is much more custom, and so we have to move some files around, delete the build directories, and then put those final executables/libraries back. 