### PR TITLE
test_eval_20250917.py: fix path issues needed to run on `Test-Corpus`

### DIFF
--- a/scripts/test_eval_20250917.py
+++ b/scripts/test_eval_20250917.py
@@ -92,9 +92,9 @@ def find_file_containing_main(project_dir: Path, j_target) -> str | None:
 def find_git_root(path: Path) -> Path:
     orig_path = path
     while True:
-        # Use `.is_dir()` instead of `.exists()` so that the `gitdir: ...` files
-        # placed in submodule roots will be ignored.
-        if (path / ".git").is_dir():
+        # Use `.exists()` to count both `.git/` directories
+        # and `.git` submodule files (containing `gitdir: ...`).
+        if (path / ".git").exists():
             return path
         new_path = path.parent
         assert new_path != path, f"found no .git directory above {orig_path!r}"


### PR DESCRIPTION
I was having trouble debugging this and figuring out what was going wrong with the paths until I cleaned it up a bit.  91997e6 and 23f11fa are the functional commits here that are fixing the issue.  d7c6d88 is also somewhat important, as it aligns how we run `crisp` here with how it's installed in Docker: using `uv run --project`.