### PR TITLE
docker: fix `hayroll` path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN cd /opt/hayroll/hayroll \
     && ln -f build/release/inliner . \
     && ln -f build/release/cleaner . \
     && rm -rf build/
-RUN ln -s /opt/hayroll/hayroll/build/hayroll /usr/local/bin/hayroll
+RUN ln -s /opt/hayroll/hayroll/hayroll /usr/local/bin/hayroll
 
 # Install CRISP tool binaries
 COPY tools/split_ffi_entry_points/ /opt/crisp-tools/split_ffi_entry_points/

--- a/Dockerfile.work
+++ b/Dockerfile.work
@@ -89,7 +89,7 @@ RUN cd /opt/hayroll/hayroll \
     && ln -f build/release/inliner . \
     && ln -f build/release/cleaner . \
     && rm -rf build/
-RUN ln -s /opt/hayroll/hayroll/build/hayroll /usr/local/bin/hayroll
+RUN ln -s /opt/hayroll/hayroll/hayroll /usr/local/bin/hayroll
 
 # Install CRISP tool binaries
 COPY tools/split_ffi_entry_points/ /opt/crisp-tools/split_ffi_entry_points/


### PR DESCRIPTION
I accidentally messed this up while merging a conflict (in #63).  Now that we move the binaries out of `build/` and then delete it, we need to use a different path for the link.