### PR TITLE
workflow: use `hayroll`'s new `--keep-src-loc`s to run `c2rust-refactor` after `hayroll`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Test on Test-Corpus (binary, runs c2rust transpile)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B01_synthetic/001_helloworld/
 
+      - name: Test on Test-Corpus (multi-file library, runs hayroll and c2rust refactor)
+        run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B02_synthetic/char_to_bool/
+
       - name: Test on Test-Corpus (multi-file binary, runs c2rust transpile and c2rust refactor)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B01_synthetic/001_helloworld_with_header/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,13 @@ jobs:
 
       - name: Test on Test-Corpus (library, runs hayroll)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B01_organic/colourblind_lib/
-      
+
       - name: Test on Test-Corpus (binary, runs c2rust transpile)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B01_synthetic/001_helloworld/
-      
+
       - name: Test on Test-Corpus (multi-file binary, runs c2rust transpile and c2rust refactor)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/B01_synthetic/001_helloworld_with_header/
-      
+
       - name: Test on Test-Corpus (uses c2rust-bitfields)
         run: ./scripts/test_eval.py Test-Corpus/Public-Tests/P01_sphincs_plus/005_sphincs_PQCgenKAT_sign_blake_128f_simple/
 

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -244,6 +244,13 @@ def do_main(args, cfg):
             n_c_code,
             src_loc_annotations=True,
             refactor_transforms=("rename_unnamed", "reorganize_definitions"),
+            hayroll=True,
+        )
+    if n_code is None and num_c_files > 1:
+        n_code = w.transpile(
+            n_c_code,
+            src_loc_annotations=True,
+            refactor_transforms=("rename_unnamed", "reorganize_definitions"),
         )
     if n_code is None:
         n_code = w.transpile(n_c_code, src_loc_annotations=True, hayroll=True)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -450,10 +450,6 @@ class Workflow:
             assert src_loc_annotations, (
                 "reorganize_definitions requires src loc annotations"
             )
-        if hayroll:
-            assert len(refactor_transforms) == 0, (
-                "refactor_transforms are not supported with hayroll yet"
-            )
 
         if hayroll:
             # Hack: edit compile_commands.json to include `arguments` field
@@ -504,28 +500,6 @@ class Workflow:
                         '--thin-binaries',
                         ))
                 exit_code, logs = sb.run(c2rust_cmd)
-
-                for transform in refactor_transforms:
-                    if exit_code == 0:
-                        c2rust_refactor_cmd = [
-                            "c2rust",
-                            "refactor",
-                            "--cargo",
-                            "--rewrite-mode",
-                            "inplace",
-                            transform,
-                        ]
-                        new_exit_code, new_logs = sb.run(
-                            c2rust_refactor_cmd, cwd=output_path
-                        )
-                        exit_code = new_exit_code
-                        logs += new_logs
-
-                if exit_code == 0:
-                    new_exit_code, new_logs = sb.run(["cargo", "clean"], cwd=output_path)
-                    exit_code = new_exit_code
-                    logs += new_logs
-
             else:
                 project_dir_rel = cfg.relative_path(art_cfg.hayroll_project_dir)
 
@@ -540,7 +514,8 @@ class Workflow:
                         sb.join(output_path),
                         '--project-dir', project_dir_rel,
                         ]
-                # hayroll already has c2rust-transpile emit src loc annotations.
+                if src_loc_annotations:
+                    c2rust_cmd.append('--keep-src-loc')
                 if art_cfg.bin_main is not None:
                     c2rust_cmd.extend((
                         '--binary', art_cfg.bin_main,
@@ -553,6 +528,26 @@ class Workflow:
                         'find', sb.join(output_path), '-name', '*.*.*', '-delete',
                     ])
                     logs = b'\n\n'.join((logs, logs2))
+
+            for transform in refactor_transforms:
+                if exit_code == 0:
+                    c2rust_refactor_cmd = [
+                        "c2rust",
+                        "refactor",
+                        "--cargo",
+                        "--rewrite-mode", "inplace",
+                        transform,
+                    ]
+                    new_exit_code, new_logs = sb.run(
+                        c2rust_refactor_cmd, cwd=output_path
+                    )
+                    exit_code = new_exit_code
+                    logs += new_logs
+
+            if exit_code == 0:
+                new_exit_code, new_logs = sb.run(["cargo", "clean"], cwd=output_path)
+                exit_code = new_exit_code
+                logs += new_logs
 
             if exit_code == 0:
                 n_rust_code = sb.commit_dir(output_path)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -468,6 +468,7 @@ class Workflow:
             sb.checkout(n_c_code)
             sb.checkout_file(COMPILE_COMMANDS_PATH, n_cc)
 
+
             # Create each directory mentioned in compile_commands.json, since
             # c2rust may assume that they already exist.
             j = n_cc.body_json()
@@ -477,17 +478,16 @@ class Workflow:
             for d in cc_dirs:
                 sb.run(['mkdir', '-p', d])
 
+
+            # Run c2rust-transpile (or Hayroll, if enabled)
             c2rust_cmd = []
-            # Run c2rust-transpile
             if not hayroll:
                 sb.run(['mkdir', '-p', output_path])
 
                 c2rust_cmd += [
-                    "c2rust",
-                    "transpile",
+                    "c2rust", "transpile",
                     sb.join(COMPILE_COMMANDS_PATH),
-                    "--output-dir",
-                    sb.join(output_path),
+                    "--output-dir", sb.join(output_path),
                     "--emit-build-files",
                 ]
                 if src_loc_annotations:
@@ -517,33 +517,37 @@ class Workflow:
                     '--binary', art_cfg.bin_main,
                     '--thin-binaries',
                     ))
+
             exit_code, logs = sb.run(c2rust_cmd)
 
+
+            # Hayroll produces a bunch of temporary files as it runs.  Remove
+            # them so they don't clutter the output.
             if hayroll and exit_code == 0:
                 exit_code, logs2 = sb.run([
                     'find', sb.join(output_path), '-name', '*.*.*', '-delete',
                 ])
                 logs = b'\n\n'.join((logs, logs2))
 
+
+            # Apply any requested c2rust-refactor transforms
             for transform in refactor_transforms:
                 if exit_code == 0:
                     c2rust_refactor_cmd = [
-                        "c2rust",
-                        "refactor",
+                        "c2rust", "refactor",
                         "--cargo",
                         "--rewrite-mode", "inplace",
                         transform,
                     ]
-                    new_exit_code, new_logs = sb.run(
-                        c2rust_refactor_cmd, cwd=output_path
-                    )
-                    exit_code = new_exit_code
-                    logs += new_logs
+                    exit_code, logs2 = sb.run(c2rust_refactor_cmd, cwd=output_path)
+                    logs = b'\n\n'.join((logs, logs2))
 
+
+            # Clean build artifacts that may be produced by c2rust-refactor.
             if exit_code == 0:
-                new_exit_code, new_logs = sb.run(["cargo", "clean"], cwd=output_path)
-                exit_code = new_exit_code
-                logs += new_logs
+                exit_code, logs2 = sb.run(["cargo", "clean"], cwd=output_path)
+                logs = b'\n\n'.join((logs, logs2))
+
 
             if exit_code == 0:
                 n_rust_code = sb.commit_dir(output_path)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -477,11 +477,12 @@ class Workflow:
             for d in cc_dirs:
                 sb.run(['mkdir', '-p', d])
 
+            c2rust_cmd = []
             # Run c2rust-transpile
             if not hayroll:
                 sb.run(['mkdir', '-p', output_path])
 
-                c2rust_cmd = [
+                c2rust_cmd += [
                     "c2rust",
                     "transpile",
                     sb.join(COMPILE_COMMANDS_PATH),
@@ -494,12 +495,6 @@ class Workflow:
                         "--reorganize-definitions",
                         "--disable-refactoring",
                     ]
-                if art_cfg.bin_main is not None:
-                    c2rust_cmd.extend((
-                        '--binary', art_cfg.bin_main,
-                        '--thin-binaries',
-                        ))
-                exit_code, logs = sb.run(c2rust_cmd)
             else:
                 project_dir_rel = cfg.relative_path(art_cfg.hayroll_project_dir)
 
@@ -508,7 +503,7 @@ class Workflow:
                 # modules.  We want it to translate `src/lib.c` to `src/lib.rs`
                 # rather than `foo/bar/baz/src/lib.rs` because overly long file
                 # paths sometimes confuse weaker LLMs.
-                c2rust_cmd = [
+                c2rust_cmd += [
                         'hayroll',
                         sb.join(COMPILE_COMMANDS_PATH),
                         sb.join(output_path),
@@ -516,18 +511,19 @@ class Workflow:
                         ]
                 if src_loc_annotations:
                     c2rust_cmd.append('--keep-src-loc')
-                if art_cfg.bin_main is not None:
-                    c2rust_cmd.extend((
-                        '--binary', art_cfg.bin_main,
-                        '--thin-binaries',
-                        ))
-                exit_code, logs = sb.run(c2rust_cmd)
 
-                if exit_code == 0:
-                    exit_code, logs2 = sb.run([
-                        'find', sb.join(output_path), '-name', '*.*.*', '-delete',
-                    ])
-                    logs = b'\n\n'.join((logs, logs2))
+            if art_cfg.bin_main is not None:
+                c2rust_cmd.extend((
+                    '--binary', art_cfg.bin_main,
+                    '--thin-binaries',
+                    ))
+            exit_code, logs = sb.run(c2rust_cmd)
+
+            if hayroll and exit_code == 0:
+                exit_code, logs2 = sb.run([
+                    'find', sb.join(output_path), '-name', '*.*.*', '-delete',
+                ])
+                logs = b'\n\n'.join((logs, logs2))
 
             for transform in refactor_transforms:
                 if exit_code == 0:


### PR DESCRIPTION
We'd like to integrate `hayroll` and `c2rust-refactor`.  However, `c2rust-refactor`'s `reorganize_definitions` requires annotations (like `#[c2rust::src_loc]` and `#[c2rust::header_src]`) from `c2rust-transpile`, which `hayroll` was removing as it wrapped `c2rust-transpile`.  How `hayroll` has a `--keep-src-loc` flag that preserves these annotations.  However, since `hayroll` handles conditional compilation, there may be different annotations on the same item that it has to merge, which it currently doesn't handle properly.  Thus, like for our other `hayroll`/`c2rust-transpile`/`c2rust-refactor` combinations, we first try `hayroll --keep-src-loc` + `c2rust-refactor` and fallback to the others if it fails.  This should hopefully cover most cases.

For a more complete solution, we may have to have `hayroll` wrap `c2rust-transpile` + `c2rust-refactor`, as `c2rust-refactor` can't maintain the conditional compilation that `hayroll` creates, as it's based on `rustc`, and `rustc` simply won't see those other `#[cfg]`s.  But we can start with this simpler solution.