### PR TITLE
agent: add instructions about counting unsafe functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 # c2rust deps
 RUN apt-get install -y \
     build-essential llvm llvm-dev clang libclang-dev cmake \
-    libssl-dev pkg-config python3 git bear ripgrep
+    libssl-dev pkg-config python3 git bear ripgrep jq
 
 # Install the toolchain used to build c2rust
 RUN rustup toolchain add \

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -345,7 +345,7 @@ def _find_unsafe_impl(cfg: Config, mvir: MVIR,
         for name, node_id in code.files.items()
         if name.endswith('.rs')
     })
-    p = subprocess.run(('cargo', 'run', '--release'),
+    p = subprocess.run(('cargo', 'run', '--release', '--', '--stdin-cbor'),
         cwd=find_unsafe_dir,
         input=input_cbor_bytes, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -109,7 +109,12 @@ After refactoring, make sure the code still passes the tests.  Run the tests usi
 {test_cmd}
 ```
 
-Remember, your overall goal is to reduce the amount of unsafe code in this codebase.  In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
+You can measure the amount of unsafe code remaining using this command:
+```sh
+find-unsafe --dir {cargo_dir_path} \
+    | jq '[to_entries.[].value | (.internal_unsafe_fns | length) + (.fns_containing_unsafe | length)] | add'
+```
+This counts all non-FFI-related functions that are either `unsafe fn` or contain unsafe code internally. Your goal is to reduce this metric from its initial value of {initial_unsafe_count}. In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
 '''
 
 AGENT_SAFETY_PROMPT_NO_TESTS = '''
@@ -777,6 +782,7 @@ class Workflow:
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
         prompt = prompt.format(
             cargo_dir_path = cargo_dir,
+            initial_unsafe_count = self.count_unsafe(n_code),
             test_cmd = cfg.test_command,
         )
         return agent.run_rewrite(cfg, mvir, prompt, n_code, n_test_code,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -108,6 +108,8 @@ After refactoring, make sure the code still passes the tests.  Run the tests usi
 ```sh
 {test_cmd}
 ```
+
+Remember, your overall goal is to reduce the amount of unsafe code in this codebase.  In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
 '''
 
 AGENT_SAFETY_PROMPT_NO_TESTS = '''

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -188,7 +188,6 @@ fn main() {
 
         let mut v = Visitor::default();
         v.visit_file(&ast);
-        eprintln!("{:?}", v);
         outputs.insert(file_name, v.out);
     }
 

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -97,6 +97,9 @@ struct Args {
 
     /// Read a CBOR object from stdin.  It should contain a dictionary mapping file names to file
     /// contents.
+    ///
+    /// This is mainly intended for use from CRISP, so it can pass multiple files over stdin rather
+    /// than creating temporary files.
     #[clap(long)]
     stdin_cbor: bool,
 

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -153,7 +153,11 @@ fn read_dir_into(
         if entry.file_type()?.is_dir() {
             read_dir_into(&entry.path(), dest)?;
         } else {
-            read_file_into(&entry.path(), dest)?;
+            if let Some(name) = entry.file_name().to_str() {
+                if name.ends_with(".rs") && !name.starts_with('.') {
+                    read_file_into(&entry.path(), dest)?;
+                }
+            }
         }
     }
     Ok(())

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::io::{self, Read};
-use std::path;
+use std::path::{self, PathBuf};
 use ciborium;
 use clap::Parser;
 use serde::Serialize;
@@ -88,33 +89,94 @@ impl<'ast> Visit<'ast> for Visitor {
 
 
 #[derive(Parser, Debug)]
+#[group(multiple = false, required = true)]
 struct Args {
-    /// Expect the raw contents of a single file on stdin, instead of a CBOR dictionary mapping
-    /// file names to file contents.
+    /// Read a single file from stdin and report any unsafe code it contains.
     #[clap(long)]
-    single_file: bool,
+    stdin: bool,
+
+    /// Read a CBOR object from stdin.  It should contain a dictionary mapping file names to file
+    /// contents.
+    #[clap(long)]
+    stdin_cbor: bool,
+
+    /// Read a single file from the given path.
+    #[clap(long)]
+    file: Option<PathBuf>,
+
+    /// Read all files within a directory (recursively) and report on all of them.
+    #[clap(long)]
+    dir: Option<PathBuf>,
 }
 
-fn read_files_cbor() -> HashMap<path::PathBuf, String> {
-    ciborium::from_reader(io::stdin()).unwrap()
-}
-
-fn read_files_single() -> HashMap<path::PathBuf, String> {
+fn read_stdin() -> io::Result<HashMap<PathBuf, String>> {
     let mut src = String::new();
-    io::stdin().read_to_string(&mut src).unwrap();
-    HashMap::from([
-        (path::PathBuf::from("input.rs"), src),
-    ])
+    io::stdin().read_to_string(&mut src)?;
+    Ok(HashMap::from([
+        (PathBuf::from("input.rs"), src),
+    ]))
+}
+
+fn read_stdin_cbor() -> Result<HashMap<PathBuf, String>, String> {
+    ciborium::from_reader(io::stdin())
+        .map_err(|e| e.to_string())
+}
+
+fn read_file(path: &path::Path) -> io::Result<HashMap<PathBuf, String>> {
+    let mut m = HashMap::new();
+    read_file_into(path, &mut m)?;
+    Ok(m)
+}
+
+fn read_file_into(
+    path: &path::Path,
+    dest: &mut HashMap<PathBuf, String>,
+) -> io::Result<()> {
+    let src = fs::read_to_string(path)?;
+    let old = dest.insert(path.to_owned(), src);
+    assert!(old.is_none(), "duplicate entry for {:?}", path);
+    Ok(())
+}
+
+fn read_dir(path: &path::Path) -> io::Result<HashMap<PathBuf, String>> {
+    let mut m = HashMap::new();
+    read_dir_into(path, &mut m)?;
+    Ok(m)
+}
+
+fn read_dir_into(
+    path: &path::Path,
+    dest: &mut HashMap<PathBuf, String>,
+) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            read_dir_into(&entry.path(), dest)?;
+        } else {
+            read_file_into(&entry.path(), dest)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_files(args: &Args) -> Result<HashMap<PathBuf, String>, String> {
+    if args.stdin {
+        read_stdin().map_err(|e| e.to_string())
+    } else if args.stdin_cbor {
+        read_stdin_cbor()
+    } else if let Some(ref file) = args.file {
+        read_file(file).map_err(|e| e.to_string())
+    } else if let Some(ref dir) = args.dir {
+        read_dir(dir).map_err(|e| e.to_string())
+    } else {
+        panic!("must pass at least one input option")
+    }
 }
 
 fn main() {
     let args = Args::parse();
 
-    let files = if args.single_file {
-        read_files_single()
-    } else {
-        read_files_cbor()
-    };
+    let files = read_files(&args).unwrap();
 
     let mut outputs = HashMap::new();
     for (file_name, src) in files {


### PR DESCRIPTION
This makes some improvements to the `find_unsafe` tool and prompts the agent to use it to measure its own progress.  In particular, this adds new input modes to `find_unsafe` so that the agent can run it on a directory instead of a CBOR-based archive.