### PR TITLE
Misc fixes (2026-04-08)

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -107,6 +107,8 @@ def parse_args():
 
     sandbox_run = sub.add_parser('sandbox-run')
     sandbox_run.add_argument('run_cmd', nargs='*')
+    sandbox_run.add_argument('--checkout', action='append', default=[], metavar='NODE',
+        help='check out files from this node into the sandbox')
 
     return ap.parse_args()
 
@@ -483,6 +485,9 @@ def do_sandbox_run(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
 
     with run_sandbox(cfg, mvir) as sb:
+        for node_id_str in args.checkout:
+            node_id = parse_node_id_arg(mvir, node_id_str)
+            sb.checkout(mvir.node(node_id))
         sb.run(args.run_cmd, stream = True)
 
 def main():

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -299,16 +299,14 @@ class Workflow:
             sb.checkout_file(COMPILE_COMMANDS_PATH, n_cc)
             sb.checkout(n_c_code)
 
-            # Hack: ensure all directories mentioned in compile_commands.json
-            # exist by placing an empty file in each one.
+            # Create each directory mentioned in compile_commands.json, since
+            # c2rust may assume that they already exist.
             j = n_cc.body_json()
-            n_empty = FileNode.new(mvir, '')
             sb_dir = sb.join()
-            for x in j:
-                if 'directory' in x:
-                    d = x['directory']
-                    rel_d = os.path.relpath(d, sb_dir)
-                    sb.checkout_file(os.path.join(rel_d, '.empty'), n_empty)
+            cc_dirs = {os.path.relpath(x['directory'], sb_dir)
+                for x in j if 'directory' in x}
+            for d in cc_dirs:
+                sb.run(['mkdir', '-p', d])
 
             # Run c2rust-transpile
             if not hayroll:

--- a/tools/split_ffi_entry_points/src/main.rs
+++ b/tools/split_ffi_entry_points/src/main.rs
@@ -169,7 +169,16 @@ fn add_ffi_wrapper(
         args: arg_exprs.into_iter().collect(),
     });
     let wrapper_stmt = syn::Stmt::Expr(wrapper_expr, None);
-    fn_wrapper.block.stmts.push(wrapper_stmt);
+    let unsafe_expr = syn::Expr::Unsafe(syn::ExprUnsafe {
+        attrs: Vec::new(),
+        unsafe_token: Default::default(),
+        block: syn::Block {
+            brace_token: Default::default(),
+            stmts: vec![wrapper_stmt],
+        },
+    });
+    let unsafe_stmt = syn::Stmt::Expr(unsafe_expr, None);
+    fn_wrapper.block.stmts.push(unsafe_stmt);
 
     Some(fn_wrapper.into())
 }

--- a/tools/split_ffi_entry_points/src/main.rs
+++ b/tools/split_ffi_entry_points/src/main.rs
@@ -50,6 +50,7 @@ impl<F: FnMut(&mut syn::Item) -> Option<syn::Item>> VisitMut for AddDerivedItemV
 }
 
 fn add_ffi_wrapper(
+    args: &Args,
     _db: &RootDatabase,
     _sema: &Semantics<RootDatabase>,
     _root: SyntaxNode,
@@ -168,17 +169,19 @@ fn add_ffi_wrapper(
         paren_token: syn::token::Paren::default(),
         args: arg_exprs.into_iter().collect(),
     });
-    let wrapper_stmt = syn::Stmt::Expr(wrapper_expr, None);
-    let unsafe_expr = syn::Expr::Unsafe(syn::ExprUnsafe {
-        attrs: Vec::new(),
-        unsafe_token: Default::default(),
-        block: syn::Block {
-            brace_token: Default::default(),
-            stmts: vec![wrapper_stmt],
-        },
-    });
-    let unsafe_stmt = syn::Stmt::Expr(unsafe_expr, None);
-    fn_wrapper.block.stmts.push(unsafe_stmt);
+    let mut wrapper_stmt = syn::Stmt::Expr(wrapper_expr, None);
+    if args.add_unsafe_blocks {
+        let unsafe_expr = syn::Expr::Unsafe(syn::ExprUnsafe {
+            attrs: Vec::new(),
+            unsafe_token: Default::default(),
+            block: syn::Block {
+                brace_token: Default::default(),
+                stmts: vec![wrapper_stmt],
+            },
+        });
+        wrapper_stmt = syn::Stmt::Expr(unsafe_expr, None);
+    }
+    fn_wrapper.block.stmts.push(wrapper_stmt);
 
     Some(fn_wrapper.into())
 }
@@ -342,6 +345,14 @@ impl ToTokens for ParsedMetaExportName {
 struct Args {
     /// Directory of Rust project to modify. `Cargo.toml` should reside inside this directory.
     cargo_dir_path: PathBuf,
+
+    /// Wrap the body of each generated FFI function in `unsafe { ... }`.
+    ///
+    /// This prevents an `unsafe_op_in_unsafe_fn` warning in 2024 edition, which is expected to
+    /// become a hard error in 2027 and later editions.  Earlier editions don't require this.
+    /// Since c2rust-transpile currently defaults to 2021 edition, this is off by default.
+    #[clap(long)]
+    add_unsafe_blocks: bool,
 }
 
 fn main() {
@@ -404,7 +415,7 @@ fn main() {
 
         let mut ast: syn::File = syn::parse2(ts.clone()).unwrap();
         let mut v = AddDerivedItemVisitor(|i: &mut syn::Item| -> Option<syn::Item> {
-            add_ffi_wrapper(&db, &sema, root.clone(), i)
+            add_ffi_wrapper(&args, &db, &sema, root.clone(), i)
         });
         v.visit_file_mut(&mut ast);
 


### PR DESCRIPTION
* Add a `--checkout NODE` option to `crisp sandbox-run`, useful when debugging sandbox setups that involve files from MVIR.
* Make `split_ffi` use an `unsafe` block in the body of each `_ffi` wrapper function, for compatibility with Rust 2024 (`unsafe_op_in_unsafe_fn` warning)
* When creating directories mentioned in `compile_commands.json`, run `mkdir -p` inside the sandbox instead of checking out an empty file into each directory (I ran into some issue with the empty-file strategy, but unfortunately I've forgotten the details)