### PR TITLE
workflow: pass --add-unsafe-blocks to split_ffi

### DIFF
--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -600,7 +600,8 @@ class Workflow:
         with run_sandbox(cfg, mvir) as sb:
             sb.checkout(n_tree)
 
-            exit_code, logs = sb.run(['split_ffi_entry_points', sb.join(rust_path_rel)])
+            exit_code, logs = sb.run(
+                ['split_ffi_entry_points', '--add-unsafe-blocks', sb.join(rust_path_rel)])
 
             if exit_code == 0:
                 exit_code, logs2 = sb.run([


### PR DESCRIPTION
In #93 we disabled adding `unsafe` blocks inside the `unsafe fn`s generated by `split_ffi`, since a future version of c2rust-transpile (after https://github.com/immunant/c2rust/pull/1720) won't require them.  But the current version does still require them, so we need to keep generating them for now.