### PR TITLE
Add --codex-login flag for alternative agent authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN cargo-docker-clean.sh /opt/crisp-tools/install-all.sh
 # Install codex-cli
 RUN mkdir /opt/codex-cli \
     && cd /opt/codex-cli \
-    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.107.0/codex-x86_64-unknown-linux-gnu.tar.gz \
+    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.118.0/codex-x86_64-unknown-linux-gnu.tar.gz \
     && wget --quiet "$codex_url" \
     && tar -xzf "$(basename "$codex_url")" \
     && ln -s "$PWD/codex-x86_64-unknown-linux-gnu" /usr/local/bin/codex \

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -62,6 +62,9 @@ def parse_args():
         choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
         default='default',
         help='which style of LLM-based rewriting to use')
+    main.add_argument('--codex-login', action='store_true',
+        help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
+            "requires --llm-mode=agent or --llm-mode=agent_sim_no_tests")
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
@@ -70,6 +73,9 @@ def parse_args():
         choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
         default='default',
         help='which style of LLM-based rewriting to use')
+    safety_loop.add_argument('--codex-login', action='store_true',
+        help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
+        "requires --llm-mode=agent or --llm-mode=agent_sim_no_tests")
 
     repl = sub.add_parser('repl')
     repl.add_argument('--node', '-n', action='append', metavar='[NAME=]NODE',
@@ -119,7 +125,10 @@ def parse_args():
     sandbox_run.add_argument('--checkout', action='append', default=[], metavar='NODE',
         help='check out files from this node into the sandbox')
 
-    return ap.parse_args()
+    args = ap.parse_args()
+    if getattr(args, 'codex_login', False) and getattr(args, 'llm_mode', None) not in ('agent', 'agent_sim_no_tests'):
+        ap.error('--codex-login requires --llm-mode=agent or --llm-mode=agent_sim_no_tests')
+    return args
 
 
 def parse_node_id_arg(mvir, s):
@@ -207,7 +216,7 @@ def parse_node_id(mvir, s):
 
 def do_main(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
-    w = Workflow(cfg, mvir)
+    w = Workflow(cfg, mvir, codex_login=args.codex_login)
 
     c_code_node_id = parse_node_id_arg(mvir, args.node)
     n_c_code = mvir.node(c_code_node_id)
@@ -359,7 +368,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
 def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
-    w = Workflow(cfg, mvir)
+    w = Workflow(cfg, mvir, codex_login=args.codex_login)
 
     c_code_node_id = parse_node_id_arg(mvir, args.c_code)
     n_c_code = mvir.node(c_code_node_id)

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -2,8 +2,9 @@
 Rewrite operations using AI agent tools, such as codex-cli
 """
 
-from pathspec.pathspec import PathSpec
 import os
+
+from pathspec.pathspec import PathSpec
 
 from . import llm
 from .config import Config
@@ -13,24 +14,57 @@ from .sandbox import run_sandbox
 
 AGENT_DEFAULT_MODEL = "gpt-5.4-2026-03-05"
 
-def _codex_command(subcmd: str, args: list[str]) -> list[str]:
-    config_settings = {
-        'model_providers.crisp.name': 'crisp',
-        'model_providers.crisp.base_url': llm.API_BASE,
-        #'model_providers.crisp.api_key': llm.API_KEY or 'sk-no-api-key',
-        'model_providers.crisp.env_key': 'CRISP_API_KEY',
-        'profiles.crisp.model_provider': 'crisp',
-        'profiles.crisp.model': llm.API_MODEL or AGENT_DEFAULT_MODEL,
-        # TODO: figure out the actual context limit and use it here
-        'profiles.crisp.context_length': 128 * 1024,
-    }
+def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> list[str]:
     cmd = ['codex', subcmd]
-    for k, v in config_settings.items():
-        cmd += ['-c', f'{k}={v}']
-    cmd += ['--profile', 'crisp']
-    cmd += args
 
+    if codex_login:
+        # Use the host's `codex login` credentials (auth.json).  We only
+        # override the model; everything else uses codex's defaults.
+        model = llm.API_MODEL or AGENT_DEFAULT_MODEL
+        cmd += ['--model', model]
+    else:
+        config_settings = {
+            'model_providers.crisp.name': 'crisp',
+            'model_providers.crisp.base_url': llm.API_BASE,
+            #'model_providers.crisp.api_key': llm.API_KEY or 'sk-no-api-key',
+            'model_providers.crisp.env_key': 'CRISP_API_KEY',
+            'profiles.crisp.model_provider': 'crisp',
+            'profiles.crisp.model': llm.API_MODEL or AGENT_DEFAULT_MODEL,
+            # TODO: figure out the actual context limit and use it here
+            'profiles.crisp.context_length': 128 * 1024,
+        }
+        for k, v in config_settings.items():
+            cmd += ['-c', f'{k}={v}']
+        cmd += ['--profile', 'crisp']
+
+    cmd += args
     return cmd
+
+def _inject_codex_auth(sb):
+    """Copy the host's ``auth.json`` into the container's work
+    directory so that codex-cli can authenticate using the host's
+    ``codex login`` session.
+
+    The file only lives for the lifetime of the container and is never
+    written to MVIR.  The ``.codex/`` ignore pattern in ``run_rewrite``
+    also ensures it is excluded from ``commit_dir`` output.
+    """
+
+    codex_home = os.getenv('CODEX_HOME')
+    if codex_home is None:
+        codex_home = os.path.expanduser('~/.codex')
+
+    host_auth = os.path.join(codex_home, 'auth.json')
+    if not os.path.isfile(host_auth):
+        raise CrispError(
+            '--codex-login requires a valid codex login session; '
+            'run `codex login` first')
+
+    with open(host_auth, 'rb') as f:
+        auth_bytes = f.read()
+
+    sb.checkout_file_untracked('.codex/auth.json', auth_bytes)
+
 
 def run_rewrite(
     cfg: Config,
@@ -40,17 +74,25 @@ def run_rewrite(
     test_code: TreeNode,
     cwd: str = '.',
     clean_cmds: list[list[str]] = [],
+    codex_login: bool = False,
 ) -> TreeNode:
+    # Print the warning in red so it stands out
+    WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
+        "the sandbox and could theoretically be leaked " \
+        "by commands run by the agent; please make sure " \
+        "to set limits on its usage.\033[0m"
+
+
     if 'CRISP_API_KEY' in os.environ:
-        # Print the warning in red so it stands out
-        print("\033[31mwarning: CRISP_API_KEY is being copied into " \
-              "the sandbox and could theoretically be leaked " \
-              "by commands run by the agent; please make sure " \
-              "to set limits on its usage.\033[0m")
+        print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
 
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(input_code)
         sb.checkout(test_code)
+
+        if codex_login:
+            print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
+            _inject_codex_auth(sb)
 
         codex_dir = sb.join(".codex")
         mkdir_codex = ['mkdir', '-p', codex_dir]
@@ -59,7 +101,7 @@ def run_rewrite(
             '--dangerously-bypass-approvals-and-sandbox',
             '--skip-git-repo-check',
             prompt,
-        ])
+        ], codex_login=codex_login)
         print(codex_cmd)
         all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -3,6 +3,7 @@ Rewrite operations using AI agent tools, such as codex-cli
 """
 
 import os
+import re
 
 from pathspec.pathspec import PathSpec
 
@@ -14,13 +15,25 @@ from .sandbox import run_sandbox
 
 AGENT_DEFAULT_MODEL = "gpt-5.4-2026-03-05"
 
+_SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
+
+def _snapshot_to_family_alias(model: str) -> str:
+    """
+    Convert a pinned snapshot model ID like:
+        gpt-5.4-2026-03-05 -> gpt-5.4
+    """
+    m = _SNAPSHOT_SUFFIX.match(model)
+    return m.group("alias") if m else model
+
 def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> list[str]:
     cmd = ['codex', subcmd]
 
     if codex_login:
         # Use the host's `codex login` credentials (auth.json).  We only
         # override the model; everything else uses codex's defaults.
-        model = llm.API_MODEL or AGENT_DEFAULT_MODEL
+        # The --model flag does not support snapshot-style model identifiers so
+        # we attempt to convert snapshots to model family aliases.
+        model = _snapshot_to_family_alias(llm.API_MODEL or AGENT_DEFAULT_MODEL)
         cmd += ['--model', model]
     else:
         config_settings = {

--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -56,13 +56,17 @@ class WorkContainer:
         self._checkout_tar_file(tar_io.getvalue())
 
     def checkout_file(self, rel_path, n_file):
-        assert not os.path.isabs(rel_path)
         assert isinstance(n_file, FileNode)
+        self.checkout_file_untracked(rel_path, n_file.body())
+
+    def checkout_file_untracked(self, rel_path, body):
+        assert not os.path.isabs(rel_path)
+        assert isinstance(body, bytes)
         tar_io = io.BytesIO()
         with tarfile.open(fileobj=tar_io, mode='w') as t:
             info = tarfile.TarInfo(rel_path)
-            info.size = len(n_file.body())
-            t.addfile(info, io.BytesIO(n_file.body()))
+            info.size = len(body)
+            t.addfile(info, io.BytesIO(body))
         self._checkout_tar_file(tar_io.getvalue())
 
     def commit_dir(self, rel_path, ignore_spec: PathSpec | None = None):

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -207,9 +207,10 @@ def step(f):
 
 
 class Workflow:
-    def __init__(self, cfg: Config, mvir: MVIR):
+    def __init__(self, cfg: Config, mvir: MVIR, codex_login: bool = False):
         self.cfg = cfg
         self.mvir = mvir
+        self.codex_login = codex_login
         self._step_depth = 0
 
     def accept(self, code: TreeNode, reason = None):
@@ -986,6 +987,7 @@ class Workflow:
             after_refactoring_instruction = after_refactoring_instruction,
         )
         return agent.run_rewrite(cfg, mvir, prompt, n_code, n_test_code,
+            codex_login=self.codex_login,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ])


### PR DESCRIPTION
- Add `--codex-login` CLI flag that uses the host's `codex login` session (`~/.codex/auth.json`) instead of `CRISP_API_KEY` for agent authentication. Requires `--llm-mode=agent`.