### PR TITLE
ci: run tests using docker image from the current branch, not registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             universal-ctags
-      
-      # `--push` instead of `--load` so that everything is cached first
-      # and so we don't accidentally run out of storage.
 
       - name: Set $IMAGE_PREFIX
         run: |
@@ -66,7 +63,8 @@ jobs:
             --cache-from type=registry,ref=${IMAGE_NAME}:cache \
             --cache-to   type=registry,ref=${IMAGE_NAME}:cache,mode=max \
             --target ${TARGET} \
-            --tag ${IMAGE_NAME}:latest \
+            --tag ${TARGET}:latest \
+            --load \
             .
       
       - name: docker build tractor-crisp
@@ -79,13 +77,6 @@ jobs:
             --target ${TARGET} \
             --tag ${IMAGE_NAME}:latest \
             .
-
-      - name: docker pull and docker tag tractor-crisp-user
-        run: |
-          TARGET=tractor-crisp-user
-          IMAGE_NAME=${IMAGE_PREFIX}/${TARGET}
-          docker pull ${IMAGE_NAME}:latest
-          docker tag ${IMAGE_NAME}:latest ${TARGET}:latest
 
       - uses: astral-sh/setup-uv@v6
 


### PR DESCRIPTION
CI on #94 was failing (e.g. [here](https://github.com/GaloisInc/Tractor-Crisp/actions/runs/24354701260/job/71118437606)) because it was using an outdated version of the tractor-crisp-user container to run tests.  This previously went undetected because any time we ran a tool inside the container, the arguments to the tool were compatible with both the new version and the old one.  But #94 started passing a new flag to `find-unsafe` that wasn't supported by the old version, causing CI to fail.

Codex (GPT-5.4) proposed using `docker buildx build --load` and removing the `docker pull` step so that the later steps use the image built by the earlier ones, without going through the container registry.  There was a comment saying that the current setup avoids using `--load` to keep the runner from running out of disk space, but the version with `--load` seems to work fine on #94.