### PR TITLE
Misc fixes (2026-04-13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,11 @@ RUN useradd -m crisp_sandbox_user
 ENV CRISP_SANDBOX=sudo
 ENV CRISP_SANDBOX_SUDO_USER=crisp_sandbox_user
 
+# Enable sparse registry for the sandbox user
+RUN mkdir -v /home/crisp_sandbox_user/.cargo \
+    && cp -v $CARGO_HOME/config.toml /home/crisp_sandbox_user/.cargo/config.toml \
+    && chown -Rv crisp_sandbox_user:crisp_sandbox_user /home/crisp_sandbox_user/.cargo
+
 # CRISP setup.  This comes last because it changes the most often.
 WORKDIR /opt/tractor-crisp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,9 @@ RUN echo "export PATH=$PATH:/usr/local/cargo/bin" >>/etc/profile
 
 FROM tractor-crisp-user AS tractor-crisp
 
+# Additional dependencies for scripts
+RUN apt-get install -y universal-ctags
+
 # Set up sudo so CRISP can use it for sandboxing
 RUN apt-get install -y sudo
 RUN sed -i -e 's,secure_path=",&/usr/local/cargo/bin:,' /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ WORKDIR /opt/tractor-crisp
 
 COPY pyproject.toml uv.lock ./
 COPY crisp/ ./crisp/
+COPY scripts/test_eval.py ./scripts/test_eval.py
 RUN uv sync
 # FIXME: currently disabled in favor of the wrapper script below.  Some parts
 # of CRISP use `os.path.dirname(__file__)` to find related files, but `uv`

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN echo "export PATH=$PATH:/usr/local/cargo/bin" >>/etc/profile
 
 FROM tractor-crisp-user AS tractor-crisp
 
-# Additional dependencies for scripts
+# Dependencies for `scripts/test_eval.py`
 RUN apt-get install -y universal-ctags
 
 # Set up sudo so CRISP can use it for sandboxing
@@ -118,9 +118,9 @@ ENV CRISP_SANDBOX=sudo
 ENV CRISP_SANDBOX_SUDO_USER=crisp_sandbox_user
 
 # Enable sparse registry for the sandbox user
-RUN mkdir -v /home/crisp_sandbox_user/.cargo \
-    && cp -v $CARGO_HOME/config.toml /home/crisp_sandbox_user/.cargo/config.toml \
-    && chown -Rv crisp_sandbox_user:crisp_sandbox_user /home/crisp_sandbox_user/.cargo
+RUN mkdir -v /home/$CRISP_SANDBOX_SUDO_USER/.cargo \
+    && cp -v $CARGO_HOME/config.toml /home/$CRISP_SANDBOX_SUDO_USER/.cargo/ \
+    && chown -Rv $CRISP_SANDBOX_SUDO_USER:$CRISP_SANDBOX_SUDO_USER /home/$CRISP_SANDBOX_SUDO_USER/.cargo
 
 # CRISP setup.  This comes last because it changes the most often.
 WORKDIR /opt/tractor-crisp

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -240,11 +240,37 @@ def do_main(args, cfg):
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
 
 def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
+    # Try at most this many times in total to make the code safe.
     llm_safety_tries = int(os.environ.get("LLM_SAFETY_TRIES", "3"))
+    # If set, bail out if the LLM fails to improve safety of the code for
+    # several consecutive iterations.  For example, if LLM_SAFETY_TRIES=100 and
+    # LLM_SAFETY_MAX_CONSECUTIVE_FAILURES=3, the loop will stop if it makes no
+    # progress for 3 iterations in a row, on the assumption that the LLM has
+    # gotten stuck somehow, but otherwise will keep going for 100 iteratiors.
+    max_consecutive_failures = \
+            int(os.environ.get("LLM_SAFETY_MAX_CONSECUTIVE_FAILURES", llm_safety_tries))
+
+    best_unsafe_count = None
+    consecutive_failures = 0
+
     for safety_try in range(llm_safety_tries):
         unsafe_count = w.count_unsafe(n_code)
         if unsafe_count == 0:
             break
+
+        # Update consecutive failure count
+        if best_unsafe_count is None or unsafe_count < best_unsafe_count:
+            best_unsafe_count = unsafe_count
+            consecutive_failures = 0
+        else:
+            # The previous iteration failed to make progress.  (Note the LLM
+            # may have run normally and produced working code, but if it didn't
+            # improve the unsafe count, we still consider that to be a failed
+            # iteration.)
+            consecutive_failures += 1
+            if consecutive_failures >= max_consecutive_failures:
+                print(f'stopping due to {consecutive_failures} consecutive failures')
+                break
 
         try:
             match args.llm_mode:

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -380,7 +380,7 @@ def _find_unsafe_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
 
     if exit_code == 0:
         if isinstance(logs, bytes):
-            logs = logs.decode('utf-8')
+            logs = logs.decode()
 
         json = sb.commit_file('unsafe.json').body_str()
     else:

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -371,43 +371,41 @@ def crisp_git_state(subdir=None) -> str:
 
 
 @analysis
-def _find_unsafe_impl(cfg: Config, mvir: MVIR,
-        code: TreeNode, commit: str) -> FindUnsafeAnalysisNode:
-    find_unsafe_dir = os.path.join(_CRISP_DIR, 'tools/find_unsafe')
+def _find_unsafe_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
+        code: TreeNode, cmd: list[str]) -> FindUnsafeAnalysisNode:
+    sb.checkout(code)
 
-    subprocess.run(('cargo', 'build', '--release'),
-        cwd=find_unsafe_dir, check=True)
+    cmd_wrapped = ['sh', '-c', shlex.join(cmd) + ' >unsafe.json']
+    exit_code, logs = sb.run(cmd_wrapped)
 
-    input_cbor_bytes = cbor.dumps({
-        name: mvir.node(node_id).body_str()
-        for name, node_id in code.files.items()
-        if name.endswith('.rs')
-    })
-    p = subprocess.run(('cargo', 'run', '--release', '--', '--stdin-cbor'),
-        cwd=find_unsafe_dir,
-        input=input_cbor_bytes, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if exit_code == 0:
+        if isinstance(logs, bytes):
+            logs = logs.decode('utf-8')
 
-    if p.returncode != 0:
-        print('command failed with exit code %d' % p.returncode)
-        print(' --- stdout ---\n%s\n' % p.stdout.decode('utf-8', errors='replace'))
-        print(' --- stderr ---\n%s\n' % p.stderr.decode('utf-8', errors='replace'))
-        p.check_returncode()
+        json = sb.commit_file('unsafe.json').body_str()
+    else:
+        json = ''
+        crate_out = CrateNode.new(mvir, defs = {})
 
-    # Check that stdout is valid json
-    _ = json.loads(p.stdout.decode('utf-8'))
-
-    n = FindUnsafeAnalysisNode.new(
-            mvir,
-            code = code.node_id(),
-            commit = commit,
-            stderr = p.stderr.decode('utf-8'),
-            body = p.stdout,
-            )
-    return n
+    n_op = FindUnsafeAnalysisNode.new(
+        mvir,
+        # Note that saving `logs` here duplicates the entire JSON/`CrateNode`
+        # output in the successful case.
+        body = json,
+        code = code.node_id(),
+        cmd = cmd,
+        exit_code = exit_code,
+        logs = logs,
+    )
+    if exit_code != 0:
+        raise CrispError('find_unsafe failed', n_op)
+    return n_op
 
 def find_unsafe(cfg: Config, mvir: MVIR, code: TreeNode) -> CompileCommandsOpNode:
-    commit = crisp_git_state('tools/find_unsafe')
-    return _find_unsafe_impl(cfg, mvir, code, commit)
+    with run_sandbox(cfg, mvir) as sb:
+        cmd = ['find-unsafe', '--dir', sb.join('.')]
+        n_op = _find_unsafe_impl(cfg, mvir, sb, code, cmd)
+    return n_op
 
 
 @analysis

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -751,15 +751,16 @@ class InlineErrorsOpNode(Node):
     check_json = property(lambda self: self._metadata['check_json'])
 
 class FindUnsafeAnalysisNode(Node):
-    KIND = 'find_unsafe_analysis'
+    KIND = 'find_unsafe_analysis_v2'
     code: Metadata[NodeId]
-    # Commit hash of the `find_unsafe` version that was used
-    commit: Metadata[str]
-    stderr: Metadata[str]
+    cmd: Metadata[list[str]]
+    exit_code: Metadata[int]
+    logs: Metadata[str]
     # `body` stores the JSON output
 
     code = property(lambda self: self._metadata['code'])
-    commit = property(lambda self: self._metadata['commit'])
+    cmd = property(lambda self: self._metadata['cmd'])
+    exit_code = property(lambda self: self._metadata['exit_code'])
     stderr = property(lambda self: self._metadata['stderr'])
 
 class EditOpNode(Node):
@@ -934,3 +935,14 @@ def migrate_split_ffi_op(metadata: dict[str, Any]):
     metadata['kind'] = 'split_ffi_op_v2'
     # `commit` field was removed
     del metadata['commit']
+
+@migration('find_unsafe_analysis')
+def migrate_find_unsafe_analysis(metadata: dict[str, Any]):
+    metadata['kind'] = 'find_unsafe_analysis_v2'
+    # `commit` field was removed
+    del metadata['commit']
+    # `cmd` and `exit_code` fields were added
+    metadata['cmd'] = ['find-unsafe', '--stdin-cbor']
+    metadata['exit_code'] = 0
+    # `stderr` was renamed to `logs`
+    metadata['logs'] = metadata['stderr']


### PR DESCRIPTION
* Include `test_eval.py` in the docker container, so we can use it when running all of CRISP under docker.
* Use `find-unsafe` from `$PATH` instead of building it with Cargo on demand.  The build was failing because we don't copy the `tools/` directory into the full `tractor-crisp` container.  However, `find-unsafe` is already installed into `$PATH` within the sandbox, so it seemed easiest to switch to running `find-unsafe` in the sandbox the same way we run all of the other helper tools.
* Add a new `LLM_SAFETY_MAX_CONSECUTIVE_FAILURES` env var.  When using `--llm-mode agent` on large projects, it's useful to set `LLM_SAFETY_TRIES` very high (e.g. 100 or more), since it edits only a small portion of the codebase on each run.  But this could waste a lot of tokens if the agent gets stuck and repeatedly runs without making progress.  This new option cuts off the loop if the agent goes too many iterations without improving the unsafe count beyond its previous best.
* Update `Dockerfile` to install `ctags` (needed for running `test_eval.py`) into the `tractor-crisp` container.  This isn't needed in `tractor-crisp-user` since it's used for running CRISP itself, not for running any of the sandboxed tools that CRISP calls out to.
* Update `Dockerfile` to add the Cargo sparse registry config to `~crisp_sandbox_user/.cargo/config.toml`.  Currently we put this setting in `$CARGO_HOME/config.toml`, which for `root` expands to `/usr/local/cargo/config.toml`, but `crisp_sandbox_user` doesn't have `$CARGO_HOME` set in its environment and defaults to `~/.cargo/config.toml` instead.