### PR TITLE
Better handling of the case where no tests are available

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -58,14 +58,16 @@ def parse_args():
 
     main = sub.add_parser('main')
     main.add_argument('node', nargs='?', default='c_code')
-    main.add_argument('--llm-mode', choices=('default', 'no_ffi', 'agent', 'agent_no_tests'),
+    main.add_argument('--llm-mode',
+        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
         default='default',
         help='which style of LLM-based rewriting to use')
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
     safety_loop.add_argument('node', nargs='?', default='current')
-    safety_loop.add_argument('--llm-mode', choices=('default', 'no_ffi', 'agent', 'agent_no_tests'),
+    safety_loop.add_argument('--llm-mode',
+        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
         default='default',
         help='which style of LLM-based rewriting to use')
 
@@ -283,7 +285,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
                     continue
 
-                case 'agent_no_tests':
+                case 'agent_sim_no_tests':
                     # Don't provide the test code, so the agent can't
                     # accidentally find the tests.  Note this has the side
                     # effect of not providing the original C code, since we
@@ -295,7 +297,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         w.accept(n_new_code, ('main', 'safety', safety_try))
                         n_code = n_new_code
 
-                    # `agent_no_tests` simulates the mode where no tests are
+                    # `agent_sim_no_tests` simulates the mode where no tests are
                     # available and the only success criteria that CRISP can
                     # check are whether the code builds or not.  We actually do
                     # run the tests here, but if the accepted `n_code` ever

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -284,7 +284,12 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     continue
 
                 case 'agent_no_tests':
-                    n_new_code = w.agent_safety(n_code, n_c_code)
+                    # Don't provide the test code, so the agent can't
+                    # accidentally find the tests.  Note this has the side
+                    # effect of not providing the original C code, since we
+                    # don't currently distinguish test code from the rest of
+                    # the C code.
+                    n_new_code = w.agent_safety_no_tests(n_code)
                     n_op_check = w.cargo_check_json_op(n_new_code)
                     if n_op_check.passed:
                         w.accept(n_new_code, ('main', 'safety', safety_try))

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -234,9 +234,12 @@ def do_main(args, cfg):
     w.accept(n_code, ('main', 'transpile'))
 
     n_code = w.split_ffi(n_code)
+    if not w.cargo_check_json_op(n_code).passed:
+        print('error: build failed after split_ffi')
+        return
     if not w.test(n_code, n_c_code):
         print('error: tests failed after split_ffi')
-        return None
+        return
     w.accept(n_code, ('main', 'split_ffi'))
 
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)

--- a/crisp/config.py
+++ b/crisp/config.py
@@ -51,7 +51,10 @@ class Config(ConfigBase):
     # this command are interpreted relative to `base_dir` (specifically, the
     # command is run in a sandbox directory where a subset of the files from
     # `base_dir` have been checked out).
-    test_command: str
+    #
+    # If this is `None`, no tests will be run.  Operations that would normally
+    # run tests will always report that the tests passed.
+    test_command: str | None = None
     base_dir: str = '.'
     mvir_storage_dir: str = 'crisp-storage'
     # `model = None` means call `/v1/models` and pick the first from the list.

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -676,7 +676,10 @@ class Workflow:
 
     @step
     def test_op(self, code: TreeNode, c_code: TreeNode) -> TestResultNode:
-        n = analysis.run_tests(self.cfg, self.mvir, code, c_code, self.cfg.test_command)
+        test_cmd = self.cfg.test_command
+        if test_cmd is None:
+            test_cmd = 'true'
+        n = analysis.run_tests(self.cfg, self.mvir, code, c_code, test_cmd)
         return n
 
     @step
@@ -962,12 +965,13 @@ class Workflow:
         self,
         n_code: TreeNode,
         n_test_code: TreeNode,
+        # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
     ) -> TreeNode:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
 
-        if provide_test_cmd:
+        if provide_test_cmd and cfg.test_command is not None:
             after_refactoring_instruction = AGENT_AFTER_REFACTORING_RUN_TESTS \
                     .format(test_cmd = cfg.test_command)
         else:

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -104,33 +104,26 @@ Please refactor the Rust code in `{cargo_dir_path}` to avoid the use of `unsafe`
 
 HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code.
 
+{after_refactoring_instruction}
+
+You can measure the amount of unsafe code remaining using this command:
+```sh
+find-unsafe --dir {cargo_dir_path} \
+    | jq '[to_entries.[].value | (.internal_unsafe_fns | length) + (.fns_containing_unsafe | length)] | add'
+```
+This counts all non-FFI-related functions that are either `unsafe fn` or contain unsafe code internally. Your goal is to reduce this metric from its initial value of {initial_unsafe_count}. In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
+'''
+
+AGENT_AFTER_REFACTORING_RUN_TESTS = '''
 After refactoring, make sure the code still passes the tests.  Run the tests using this script:
 ```sh
 {test_cmd}
 ```
+'''.strip()
 
-You can measure the amount of unsafe code remaining using this command:
-```sh
-find-unsafe --dir {cargo_dir_path} \
-    | jq '[to_entries.[].value | (.internal_unsafe_fns | length) + (.fns_containing_unsafe | length)] | add'
-```
-This counts all non-FFI-related functions that are either `unsafe fn` or contain unsafe code internally. Your goal is to reduce this metric from its initial value of {initial_unsafe_count}. In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
-'''
-
-AGENT_SAFETY_PROMPT_NO_TESTS = '''
-Please refactor the Rust code in `{cargo_dir_path}` to avoid the use of `unsafe`, without changing its behavior.  First, examine the codebase to identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fileds) that uses `unsafe`, and plan how you would refactor it to make it safe.  Write this plan to `SAFETY_PLAN.md`.  Then carry out the refactor as planned.
-
-HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code.
-
+AGENT_AFTER_REFACTORING_BUILD = '''
 After refactoring, make sure the code still builds.
-
-You can measure the amount of unsafe code remaining using this command:
-```sh
-find-unsafe --dir {cargo_dir_path} \
-    | jq '[to_entries.[].value | (.internal_unsafe_fns | length) + (.fns_containing_unsafe | length)] | add'
-```
-This counts all non-FFI-related functions that are either `unsafe fn` or contain unsafe code internally. Your goal is to reduce this metric from its initial value of {initial_unsafe_count}. In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
-'''
+'''.strip()
 
 
 _CRISP_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -969,14 +962,21 @@ class Workflow:
         self,
         n_code: TreeNode,
         n_test_code: TreeNode,
-        prompt: str = AGENT_SAFETY_PROMPT,
+        provide_test_cmd: bool = True,
     ) -> TreeNode:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
-        prompt = prompt.format(
+
+        if provide_test_cmd:
+            after_refactoring_instruction = AGENT_AFTER_REFACTORING_RUN_TESTS \
+                    .format(test_cmd = cfg.test_command)
+        else:
+            after_refactoring_instruction = AGENT_AFTER_REFACTORING_BUILD
+
+        prompt = AGENT_SAFETY_PROMPT.format(
             cargo_dir_path = cargo_dir,
             initial_unsafe_count = self.count_unsafe(n_code),
-            test_cmd = cfg.test_command,
+            after_refactoring_instruction = after_refactoring_instruction,
         )
         return agent.run_rewrite(cfg, mvir, prompt, n_code, n_test_code,
             clean_cmds = [
@@ -987,8 +987,7 @@ class Workflow:
     def agent_safety_no_tests(
         self,
         n_code: TreeNode,
-        prompt: str = AGENT_SAFETY_PROMPT_NO_TESTS,
     ) -> TreeNode:
         cfg, mvir = self.cfg, self.mvir
         n_test_code = TreeNode.new(mvir, files={})
-        return self.agent_safety(n_code, n_test_code, prompt = prompt)
+        return self.agent_safety(n_code, n_test_code, provide_test_cmd = False)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -311,6 +311,9 @@ class Workflow:
 
         code = self.patch_cargo_toml_workspace(code)
 
+        if not self.cargo_check_json_op(code).passed:
+            print('error: build failed after transpile')
+            return None
         if not self.test(code, c_code):
             print('error: tests failed after transpile')
             return None

--- a/scripts/test_eval.py
+++ b/scripts/test_eval.py
@@ -132,7 +132,7 @@ src_globs = [
     "translated_rust/src/*/*/*.rs",
     "translated_rust/src/*/*/*/*.rs",
 ]
-test_command = """{test_command}"""
+{test_command_kv}
 
 [transpile]
 output_dir = "translated_rust"
@@ -222,18 +222,18 @@ def main():
                 f'rm {test_dir_from_base_quoted}/test_case',
                 f'rm {test_dir_from_base_quoted}/translated_rust',
             ))
+        test_command_kv = 'test_command = """{test_command}"""'.format(
+            test_command = '\n'.join(test_command_parts),
+        )
     else:
-        test_command_parts = [
-            f'cd {shlex.quote(str(project_dir_from_base / "translated_rust"))}',
-            'cargo build',
-        ]
+        test_command_kv = '# No test_command provided'
 
     cfg_parts = [
         CONFIG_TEMPLATE_STR.format(
             base_dir = base_dir_from_project,
             example_name = targets[0]['name'],
             project_dir_from_base_quoted = shlex.quote(str(project_dir_from_base)),
-            test_command = '\n'.join(test_command_parts),
+            test_command_kv = test_command_kv,
         ),
     ]
 


### PR DESCRIPTION
This branch adds the ability to leave `test_command` unset in the config file, and modifies `test_eval.py` to leave it unset when run with `--no-runtests` or `--no-git`.  Leaving it unset causes CRISP to skip running tests, and changes the agent prompt to avoid mentioning them.  This lets us use `--llm-mode agent` (with `test_command` unset) for the evaluation, instead of `--llm-mode agent_no_tests` (which is more of a debugging feature, and has been renamed to `agent_sim_no_tests` to make that a little clearer).

The specific issue we were seeing is that with `test_eval.py --no-runtests -- --llm-mode agent_no_tests`, if the agent produces code that doesn't compile, the entire CRISP loop crashes and produces no output.  This is a combination of `--no-runtests` defaulting to `test_command = "cargo build"`, since previously it wasn't legal to omit it, and `--llm-mode agent_no_tests` asserting that tests must always succeed as a debugging mechanism.