### PR TITLE
Make `TranspileConfig.output_dir` path absolute

### DIFF
--- a/crisp/config.py
+++ b/crisp/config.py
@@ -96,9 +96,9 @@ class TranspileConfig(ConfigBase):
     artifacts: list[TranspileArtifactConfig]
 
     def __post_init__(self):
-        # Check that all artifact names are distinct.
         config_dir = os.path.dirname(self.config_path)
         object.__setattr__(self, 'output_dir', os.path.join(config_dir, self.output_dir))
+        # Check that all artifact names are distinct.
         seen = set()
         for a in self.artifacts:
             assert a.name not in seen, f'duplicate entry for artifact {a.name!r}'

--- a/crisp/config.py
+++ b/crisp/config.py
@@ -97,6 +97,8 @@ class TranspileConfig(ConfigBase):
 
     def __post_init__(self):
         # Check that all artifact names are distinct.
+        config_dir = os.path.dirname(self.config_path)
+        object.__setattr__(self, 'output_dir', os.path.join(config_dir, self.output_dir))
         seen = set()
         for a in self.artifacts:
             assert a.name not in seen, f'duplicate entry for artifact {a.name!r}'


### PR DESCRIPTION
Without this fix, the `Config.relative_path()` method was throwing an`AssertionError`. To reproduce:
1. Run `LLM_SAFETY_TRIES=0 python ../test_eval.py .../colourblind_lib`. The `crisp.toml` file which this puts inside the `colourblind_lib` folder has `base_dir = "../../.."`.
2. Create a `Config`, `MVIR` and `Workflow` for `colourblind_lib`, get its `current` node, and run LLM rewriting on it to get an `n_llm_output_code` node.
3. Do `workflow.cargo_check_json_op(n_llm_output_code)`. This will raise `AssertionError: path '<parent>/Tractor-Crisp/translated_rust' is outside project base directory '<parent>/Tractor-Crisp/Test-Corpus'`.