### PR TITLE
Fix chunked encoding error

### DIFF
--- a/crisp/llm.py
+++ b/crisp/llm.py
@@ -55,9 +55,8 @@ def sse_events(resp):
     except (
         requests.exceptions.ChunkedEncodingError,
         requests.exceptions.ConnectionError
-    ):
-        if acc:
-            yield bytes(acc)
+    ) as e:
+        raise CrispError('Could not parse LLM API request response') from e
 
     # If there are bytes remaining in `acc`, don't yield them.  "If the file
     # ends in the middle of an event, before the final empty line, the

--- a/crisp/llm.py
+++ b/crisp/llm.py
@@ -29,26 +29,35 @@ def sse_events(resp):
     # A single message may span multiple lines.  We combine the lines in this
     # accumulator so we can yield the whole message as a unit.
     acc = bytearray()
-    for line in resp.iter_lines():
-        if len(line) == 0 or line.isspace():
+
+    try:
+        for line in resp.iter_lines():
+            if len(line) == 0 or line.isspace():
+                yield bytes(acc)
+                acc.clear()
+                continue
+            key, sep, value = line.partition(b':')
+            # If `sep` is missing, no special handling is required.  "Otherwise,
+            # the string is not empty but does not contain a U+003A COLON character
+            # (:).  Process the field using the steps described below, using the
+            # whole line as the field name, and the empty string as the field
+            # value."  Note that this matches the behavior of `partition`.
+            if key.lower() != b'data':
+                print('unknown SSE key %r in %r' % (key, line))
+                continue
+            # "Collect the characters on the line after the first U+003A COLON
+            # character (:), and let `value` be that string. If `value` starts with
+            # a U+0020 SPACE character, remove it from `value`."
+            if value.startswith(b' '):
+                value = value[1:]
+            acc.extend(value)
+
+    except (
+        requests.exceptions.ChunkedEncodingError,
+        requests.exceptions.ConnectionError
+    ):
+        if acc:
             yield bytes(acc)
-            acc.clear()
-            continue
-        key, sep, value = line.partition(b':')
-        # If `sep` is missing, no special handling is required.  "Otherwise,
-        # the string is not empty but does not contain a U+003A COLON character
-        # (:).  Process the field using the steps described below, using the
-        # whole line as the field name, and the empty string as the field
-        # value."  Note that this matches the behavior of `partition`.
-        if key.lower() != b'data':
-            print('unknown SSE key %r in %r' % (key, line))
-            continue
-        # "Collect the characters on the line after the first U+003A COLON
-        # character (:), and let `value` be that string. If `value` starts with
-        # a U+0020 SPACE character, remove it from `value`."
-        if value.startswith(b' '):
-            value = value[1:]
-        acc.extend(value)
 
     # If there are bytes remaining in `acc`, don't yield them.  "If the file
     # ends in the middle of an event, before the final empty line, the

--- a/crisp/llm.py
+++ b/crisp/llm.py
@@ -31,7 +31,7 @@ def sse_events(resp):
     acc = bytearray()
 
     try:
-        for line in resp.iter_lines():
+        for line in resp.iter_lines(decode_unicode=False):
             if len(line) == 0 or line.isspace():
                 yield bytes(acc)
                 acc.clear()


### PR DESCRIPTION
While running some experiments, I ran into `requests.exceptions.ChunkedEncodingError: Response ended prematurely`. Some digging suggested that this is during the LLM rewrite calls and is likely due to dropped connections / server issues. This MR attempts to fix it by wrapping the requests response handling in a `try` block, and handling `requests.exceptions`s gracefully via `except`. I ran a couple of experiments with the changed code and didn't run into these errors any more.