### PR TITLE
Fix too many open files

### DIFF
--- a/crisp/config.py
+++ b/crisp/config.py
@@ -32,10 +32,11 @@ class ConfigBase:
     def from_toml_file(cls, f, **kwargs):
         if isinstance(f, str):
             path = f
-            f = open(f, 'r')
+            with open(f, 'r') as f_:
+                d = toml.load(f_)
         else:
             path = f.name
-        d = toml.load(f)
+            d = toml.load(f)
         return cls.from_dict(d, path, **kwargs)
 
 @dataclass(frozen = True)

--- a/crisp/llm.py
+++ b/crisp/llm.py
@@ -151,46 +151,51 @@ def do_request(req, stream=False):
 
     resp_dct = {}
     resp_choices = {}
-    for evt in sse_events(resp):
-        if evt == b'[DONE]':
-            break
-        j = json.loads(evt.decode('utf-8'))
 
-        for choice_delta in j.get('choices', ()):
-            index = choice_delta['index']
-            if (choice := resp_choices.get(index)) is None:
-                choice = StreamingChoice.new()
-                resp_choices[index] = choice
+    try:
+        for evt in sse_events(resp):
+            if evt == b'[DONE]':
+                break
+            j = json.loads(evt.decode('utf-8'))
 
-            prev_role = choice.message.role
-            prev_content_len = len(choice.message.content or '')
-            prev_reasoning_content_len = len(choice.message.reasoning_content or '')
+            for choice_delta in j.get('choices', ()):
+                index = choice_delta['index']
+                if (choice := resp_choices.get(index)) is None:
+                    choice = StreamingChoice.new()
+                    resp_choices[index] = choice
 
-            choice.apply_delta(choice_delta)
+                prev_role = choice.message.role
+                prev_content_len = len(choice.message.content or '')
+                prev_reasoning_content_len = len(choice.message.reasoning_content or '')
 
-            if index == 0:
-                if choice.message.role is not None:
-                    if prev_role is None:
-                        if choice.message.reasoning_content is not None:
-                            emit(choice.message.role, choice.message.reasoning_content,
+                choice.apply_delta(choice_delta)
+
+                if index == 0:
+                    if choice.message.role is not None:
+                        if prev_role is None:
+                            if choice.message.reasoning_content is not None:
+                                emit(choice.message.role, choice.message.reasoning_content,
+                                    is_reasoning=True)
+                            if choice.message.content is not None:
+                                emit(choice.message.role, choice.message.content)
+                        else:
+                            reasoning_content = choice.message.reasoning_content or ''
+                            emit(choice.message.role, reasoning_content[prev_reasoning_content_len:],
                                 is_reasoning=True)
-                        if choice.message.content is not None:
-                            emit(choice.message.role, choice.message.content)
-                    else:
-                        reasoning_content = choice.message.reasoning_content or ''
-                        emit(choice.message.role, reasoning_content[prev_reasoning_content_len:],
-                             is_reasoning=True)
-                        content = choice.message.content or ''
-                        emit(choice.message.role, content[prev_content_len:])
-                    p.flush()
-                p.increment()
+                            content = choice.message.content or ''
+                            emit(choice.message.role, content[prev_content_len:])
+                        p.flush()
+                    p.increment()
 
-        for k, v in j.items():
-            if k == 'choices':
-                continue
-            if resp_dct.get(k) is not None:
-                continue
-            resp_dct[k] = v
+            for k, v in j.items():
+                if k == 'choices':
+                    continue
+                if resp_dct.get(k) is not None:
+                    continue
+                resp_dct[k] = v
+
+    finally:
+        resp.close()
 
     p.finish()
 

--- a/crisp/sandbox/bwrap.py
+++ b/crisp/sandbox/bwrap.py
@@ -159,17 +159,22 @@ class BwrapSandbox:
 
         printer = ChunkPrinter()
         acc = bytearray()
-        while True:
-            data = p.stdout.read(4096)
-            if len(data) == 0:
-                break
-            printer.write_bytes(data)
-            printer.flush()
-            printer.increment()
-            acc.extend(data)
-        printer.finish()
 
-        p.wait()
+        try:
+            while True:
+                data = p.stdout.read(4096)
+                if len(data) == 0:
+                    break
+                printer.write_bytes(data)
+                printer.flush()
+                printer.increment()
+                acc.extend(data)
+            printer.finish()
+
+        finally:
+            if p.stdout:
+                p.stdout.close()
+            p.wait()
 
         logs = bytes(acc)
 


### PR DESCRIPTION
While running some experiments, I ran into `OSError: Too many open files`. Some digging suggested that this is due to `open()` calls, `subprocess.Popen()` calls and responses not being closed, leading to too many open files. This can be gotten around by setting `ulimit -Sn` to a higher value (limit is the value of `ulimit -Hn`) before running the experiments, but this is a workaround instead of an actual fix. Hopefully the changes in this MR – `with open`, `p.stdout.close()` and `resp.close()` – are more of an actual fix.

I ran a couple of experiments with the changed code and a higher `ulimit` and didn't run into these errors any more.