### PR TITLE
test_eval: add clar suite support & suite selector

### DIFF
--- a/scripts/test_eval.py
+++ b/scripts/test_eval.py
@@ -8,6 +8,7 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 import toml
 
@@ -16,22 +17,48 @@ import toml
 class Args:
     project_dir: Path
     extra_test_dirs: list[Path]
-    runtests: bool
     git: bool
+    relax_implicit_none: bool
+    cmake_preset: str | None
+    suite: str
     main_args: list[str]
+
+
+def detect_suites(case_dir: Path) -> list[str]:
+    # Keep suite detection limited to paths this script itself assumes later.
+    has_runtests = (case_dir / "test_vectors").is_dir()
+    has_clar = (
+        (case_dir / "tests").is_dir()
+        and (case_dir / "tests/CMakeLists.txt").is_file()
+    )
+
+    suites = []
+    if has_runtests:
+        suites.append("runtests")
+    if has_clar:
+        suites.append("clar")
+    return suites
 
 
 def parse_args() -> Args:
     ap = argparse.ArgumentParser()
     ap.add_argument("project_dir", type=Path)
+    ap.add_argument("--suite",
+        choices=("auto", "runtests", "clar", 'none'),
+        default="auto",
+        help="which test suite to use: auto-detect one, force a specific suite, or disable tests with 'none'")
+    ap.add_argument("--relax-implicit-none",
+        action='store_true', dest='relax_implicit_none',
+        help="when --suite=auto and no usable suites are detected, continue with suite='none' instead of raising an error")
+    ap.add_argument("--cmake-preset",
+        dest='cmake_preset',
+        help="name of CMake build preset to use when CMakePresets.json has multiple buildPresets")
     ap.add_argument('--extra-test-dir',
         type=Path, action='append', default=[], dest='extra_test_dirs',
         help='run extra test vectors from this directory')
-    ap.add_argument("--no-runtests", action='store_false', dest='runtests',
-        help="don't import `runtests` scripts or use them in `test_command`")
     ap.add_argument("--no-git", action='store_false', dest='git',
         help="don't require the project dir to be inside a git repository "
-            '(implies --no-runtests)')
+            '(implies runtests suite is unavailable)')
     ap.add_argument("main_args", nargs='*',
         help='extra arguments to pass to `crisp main`')
     return Args(**ap.parse_args().__dict__)
@@ -153,19 +180,78 @@ def relpath(path: Path, start: Path) -> Path:
     return Path(os.path.relpath(path, start))
 
 
+# Attempt to select a preset from a list of presets.
+def select_cmake_build_preset(build_presets: list[dict], requested: str | None) -> str:
+    preset_names = [p['name'] for p in build_presets]
+
+    # Try to get requested preset.
+    if requested is not None:
+        if requested not in preset_names:
+            raise RuntimeError(
+                f'Unknown CMake build preset {requested!r}; '
+                f'available presets: {preset_names}')
+        return requested
+
+    # No preset requested, behavior depends on how many presets exist.
+    match len(build_presets):
+        case 1:
+            return build_presets[0]['name']
+        case 0:
+            raise RuntimeError('CMakePresets.json contains no buildPresets')
+        case _:
+            raise RuntimeError(
+                f'Multiple CMake build presets found: {preset_names}. '
+                'Rerun with --cmake-preset <name>.')
+
+
 def main():
     args = parse_args()
-
-    if not args.git:
-        args.runtests = False
-    if not args.runtests:
-        assert len(args.extra_test_dirs) == 0, \
-            '--extra-test-dirs is not supported with --no-runtests'
 
     # For consistency, `foo_dir` is always an absolute path in this code.
     # Relative paths are always `foo_dir_from_bar`, meaning the path of
     # `foo_dir` relative to `bar_dir`.
     args.project_dir = args.project_dir.resolve()
+
+    # Detect what suites are present in project_dir.
+    if args.suite == 'none':
+        suite = 'none'
+    else:
+        suites = detect_suites(args.project_dir)
+
+        # Running with `--no-git` tries to filter out 'runtests', depending on other conditions/parameters.
+        if not args.git:
+            if args.suite == 'runtests':
+                raise RuntimeError(f'\'runtests\' is not supported with \'--no-git\'.')
+            if len(suites) == 1 and suites[0] == 'runtests':
+                if not args.relax_implicit_none:
+                    raise RuntimeError(f'Only \'runtests\' is available, and is not supported with \'--no-git\'. Did you mean to include \'--suite none\'?')
+                else:
+                    print('Warning: available suites reduced to zero due to \'--no-git\'. \'--relax-implicit-none\' will resolve `suite` to `none`.', file=sys.stderr)
+            suites = [s for s in suites if s != "runtests"]
+
+        # Case 1) suite is auto.
+        if args.suite == 'auto':
+            match len(suites):
+                case 0 if args.relax_implicit_none:
+                    suite = 'none'
+                case 0 if not args.relax_implicit_none:
+                    raise RuntimeError(f'No test suites were detected. Rerun with \'--suite none\' or \'--relax-implicit-none\' if this is intentional.')
+                case 1:
+                    suite = suites[0]
+                case n if n > 1:
+                    raise RuntimeError(f'Multiple test suites were detected: {suites}. Rerun with \'--suite X\' to pick one.')
+                case _:
+                    raise RuntimeError("Unreachable")
+        # Case 2) suite is set.
+        else:
+            if args.suite in suites:
+                suite = args.suite
+            else:
+                raise RuntimeError(f'\'{args.suite}\' test suite not found, available suites: {suites}.')
+
+    if suite != "runtests":
+        assert len(args.extra_test_dirs) == 0, \
+            '--extra-test-dirs is only supported on runtests suites'
     args.extra_test_dirs = [path.resolve() for path in args.extra_test_dirs]
 
     # `cmake_dir` is the directory that contains the top-level
@@ -179,12 +265,17 @@ def main():
             f'CMakeLists.txt not found at {cmakelists_path} or {new_cmakelists_path}'
 
     cmake_extra_args = []
+    selected_cmake_preset = None
 
     cmake_presets_path = cmake_dir / 'CMakePresets.json'
     if cmake_presets_path.exists():
         j_presets = json.load(cmake_presets_path.open())
-        assert len(j_presets['buildPresets']) == 1, 'expected exactly one entry in buildPresets'
-        preset_name = j_presets['buildPresets'][0]['name']
+        build_presets = j_presets.get('buildPresets', [])
+        suites_that_support_build_preset_selection = ['clar']
+        if len(build_presets) != 1 and suite not in suites_that_support_build_preset_selection:
+            raise RuntimeError(f'\'buildPresets\' selection is only supported by {suites_that_support_build_preset_selection}')
+        preset_name = select_cmake_build_preset(build_presets, args.cmake_preset)
+        selected_cmake_preset = preset_name
         cmake_extra_args.extend(('--preset', preset_name))
 
     # Extract CMake target info
@@ -201,32 +292,60 @@ def main():
     cmake_dir_from_project = cmake_dir.relative_to(args.project_dir)
 
     # Assemble test commands
-    if args.runtests:
-        test_command_parts = [
-            TEST_COMMAND_PREAMBLE.format(
-                project_dir_from_base_quoted = shlex.quote(str(project_dir_from_base)),
-            ),
-        ]
-        for test_dir in args.extra_test_dirs:
-            test_dir_from_base = test_dir.relative_to(base_dir)
-            test_dir_from_base_quoted = shlex.quote(str(test_dir_from_base))
-            project_dir_from_test = relpath(args.project_dir, test_dir)
-            project_dir_from_test_quoted = shlex.quote(str(project_dir_from_test))
-            test_command_parts.extend((
-                f'ln -sf {project_dir_from_test_quoted}/test_case {test_dir_from_base_quoted}/test_case',
-                f'ln -sf {project_dir_from_test_quoted}/translated_rust {test_dir_from_base_quoted}/translated_rust',
-                f'python3 -m runtests.ci -s {test_dir_from_base_quoted} --verbose',
-                f'python3 -m runtests.rust -s {test_dir_from_base_quoted} --verbose',
-                # `commit_dir` currently doesn't support symlinks, so remove them
-                # when done.
-                f'rm {test_dir_from_base_quoted}/test_case',
-                f'rm {test_dir_from_base_quoted}/translated_rust',
-            ))
-        test_command_kv = 'test_command = """{test_command}"""'.format(
-            test_command = '\n'.join(test_command_parts),
-        )
-    else:
-        test_command_kv = '# No test_command provided'
+    match suite:
+        case "runtests":
+            test_command_parts = [
+                TEST_COMMAND_PREAMBLE.format(
+                    project_dir_from_base_quoted = shlex.quote(str(project_dir_from_base)),
+                ),
+            ]
+            for test_dir in args.extra_test_dirs:
+                test_dir_from_base = test_dir.relative_to(base_dir)
+                test_dir_from_base_quoted = shlex.quote(str(test_dir_from_base))
+                project_dir_from_test = relpath(args.project_dir, test_dir)
+                project_dir_from_test_quoted = shlex.quote(str(project_dir_from_test))
+                test_command_parts.extend((
+                    f'ln -sf {project_dir_from_test_quoted}/test_case {test_dir_from_base_quoted}/test_case',
+                    f'ln -sf {project_dir_from_test_quoted}/translated_rust {test_dir_from_base_quoted}/translated_rust',
+                    f'python3 -m runtests.ci -s {test_dir_from_base_quoted} --verbose',
+                    f'python3 -m runtests.rust -s {test_dir_from_base_quoted} --verbose',
+                    # `commit_dir` currently doesn't support symlinks, so remove them
+                    # when done.
+                    f'rm {test_dir_from_base_quoted}/test_case',
+                    f'rm {test_dir_from_base_quoted}/translated_rust',
+                ))
+            test_command_kv = 'test_command = """{test_command}"""'.format(
+                test_command = '\n'.join(test_command_parts),
+            )
+        case "clar":
+            lib_target_name = None
+            for target in targets:
+                if target["type"] in ("SHARED_LIBRARY", "STATIC_LIBRARY"):
+                    lib_target_name = target["name"]
+                    break
+            if lib_target_name is None:
+                lib_target_name = targets[0]["name"]
+            rust_lib_basename = lib_target_name.replace("-", "_")
+            clar_preset_args = ''
+            if selected_cmake_preset is not None:
+                clar_preset_args = f'--preset {shlex.quote(selected_cmake_preset)}'
+
+            test_command_parts = [
+                "set -e",
+                f'cd {shlex.quote(str(project_dir_from_base))}',
+                "cargo build --manifest-path translated_rust/Cargo.toml",
+                f'RUST_SO="$PWD/translated_rust/target/debug/lib{rust_lib_basename}.so"',
+                'cmake -S tests -B tests/build {clar_preset_args} -DLIB_LINK_PATH="$RUST_SO"'.format(
+                    clar_preset_args=clar_preset_args,
+                ),
+                "cmake --build tests/build",
+                "./tests/build/tests",
+            ]
+            test_command_kv = 'test_command = """{test_command}"""'.format(
+                test_command = "\n".join(test_command_parts),
+            )
+        case _:
+            test_command_kv = '# No test_command provided'
 
     cfg_parts = [
         CONFIG_TEMPLATE_STR.format(
@@ -345,7 +464,7 @@ def main():
     commit_paths = [
         cmake_dir,
     ]
-    if args.runtests:
+    if suite == 'runtests':
         commit_paths.extend((
             base_dir / "Cargo.toml",
         ))
@@ -359,7 +478,7 @@ def main():
             test_dir / "CMakeLists.txt",
             test_dir / "CMakePresets.json",
         ))
-        if args.runtests:
+        if suite == 'runtests':
             commit_paths.extend((
                 test_dir / "runner",
                 test_dir / "test_vectors",
@@ -373,14 +492,16 @@ def main():
         # CRISP outputs that the user may have checked out into the directory
         'translated_rust/', 'compile_commands.json',
     ]
-    if not args.runtests:
+    if suite != 'runtests':
         commit_excludes.extend((
             # Exclude test runner and test vectors as in official T&E packaging
             # scripts.  This ensures the agent won't stumble upon the tests
-            # when running with `--no-runtests` on a checkout that actually
+            # when running with `--suites none` on a checkout that actually
             # does include the tests.
             'runner/', 'test_vectors/',
         ))
+    # Exclude clar artifacts when not clar, basically same as above.
+    if suite != 'clar': commit_excludes.extend(('tests/',))
     commit_exclude_args = ['--exclude=' + excl for excl in commit_excludes]
 
     run_crisp(args, ["commit", "-t", "c_code", *commit_exclude_args,


### PR DESCRIPTION
Preliminary (-ish) PR for adding clar support. 

In addition to that, it introduces a new `--suites` flag and folds some other flags into it (ex. `--no-runtests` is now `--suites none`). Still iffy about backwards compatibility, we'll see what CI has to say. 