### PR TITLE
Update Codex to v0.132.0 and its parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,10 +89,10 @@ RUN cargo-docker-clean.sh /opt/crisp-tools/install-all.sh
 # Install codex-cli
 RUN mkdir /opt/codex-cli \
     && cd /opt/codex-cli \
-    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.118.0/codex-x86_64-unknown-linux-gnu.tar.gz \
+    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.132.0/codex-x86_64-unknown-linux-musl.tar.gz \
     && wget --quiet "$codex_url" \
     && tar -xzf "$(basename "$codex_url")" \
-    && ln -s "$PWD/codex-x86_64-unknown-linux-gnu" /usr/local/bin/codex \
+    && ln -s "$PWD/codex-x86_64-unknown-linux-musl" /usr/local/bin/codex \
     && rm "$(basename "$codex_url")"
 
 # Append the location of the Rust binaries to PATH

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -50,6 +50,9 @@ def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> l
             cmd += ['-c', f'{k}={v}']
         cmd += ['--profile', 'crisp']
 
+    cmd += ['-c', 'model_reasoning_effort="high"',
+            # Fast mode uses 1.5-2x more tokens, so use the standard tier
+            '-c', 'service_tier="standard"']
     cmd += args
     return cmd
 

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -13,7 +13,7 @@ from .error import CrispError
 from .mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
 from .sandbox import run_sandbox
 
-AGENT_DEFAULT_MODEL = "gpt-5.4-2026-03-05"
+AGENT_DEFAULT_MODEL = "gpt-5.5-2026-04-23"
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
 


### PR DESCRIPTION
- **docker: update Codex to v0.132.0**
- **agent: update model to gpt-5.5**
- **agent: set reasoning and tier to high/standard (down from fast)**
