### PR TITLE
agent: carry SAFETY_PLAN.md across safety loop iterations

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -20,7 +20,8 @@ from .analysis import COMPILE_COMMANDS_PATH
 from .config import Config
 from .error import CrispError
 from .mvir import MVIR, NodeId, FileNode, TreeNode, LlmOpNode, \
-    TestResultNode, CompileCommandsOpNode, TranspileOpNode, SplitFfiOpNode
+    TestResultNode, CompileCommandsOpNode, TranspileOpNode, SplitFfiOpNode, \
+    CodexAgentOpNode
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir, set_keep_work_dir
 from .workflow import Workflow
@@ -255,6 +256,28 @@ def do_main(args, cfg):
 
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
 
+
+def prior_agent_plans(mvir, n_code) -> TreeNode | None:
+    # Look up the node which produced `n_code` and return the planning files for that step.
+    # This lets a resumed safety-loop pick up the previous `SAFETY_PLAN.md` if it exists.
+    matches = [
+        ie for ie in mvir.index(n_code.node_id())
+        if ie.kind == CodexAgentOpNode.KIND and ie.key == 'new_code'
+    ]
+
+    match matches:
+        case [ie]:
+            op_node = mvir.node(ie.node_id)
+            return mvir.node(op_node.planning_files)
+        case []:
+            return None
+        case _:
+            raise CrispError(
+                f'multiple Codex agent ops produced code node {n_code.node_id()}: '
+                + ', '.join(str(ie.node_id) for ie in matches)
+            )
+
+
 def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     # Try at most this many times in total to make the code safe.
     llm_safety_tries = int(os.environ.get("LLM_SAFETY_TRIES", "3"))
@@ -268,7 +291,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
     best_unsafe_count = None
     consecutive_failures = 0
-    n_plans = TreeNode.new(mvir, files={})
+    n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
 
     for safety_try in range(llm_safety_tries):
         unsafe_count = w.count_unsafe2(n_code)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -268,6 +268,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
     best_unsafe_count = None
     consecutive_failures = 0
+    n_plans = TreeNode.new(mvir, files={})
 
     for safety_try in range(llm_safety_tries):
         unsafe_count = w.count_unsafe2(n_code)
@@ -291,7 +292,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
         try:
             match args.llm_mode:
                 case 'agent':
-                    n_new_code = w.agent_safety(n_code, n_c_code)
+                    n_new_code, n_plans = w.agent_safety(n_code, n_c_code, n_plans)
                     n_op_test = w.test_op(n_new_code, n_c_code)
                     n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
                     if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
@@ -306,7 +307,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     # effect of not providing the original C code, since we
                     # don't currently distinguish test code from the rest of
                     # the C code.
-                    n_new_code = w.agent_safety_no_tests(n_code)
+                    n_new_code, n_plans = w.agent_safety_no_tests(n_code, n_plans)
                     n_op_check = w.cargo_check_json_op(n_new_code)
                     n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
                     if n_op_check.passed and n_op_unsafe.exit_code == 0:

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -3,6 +3,7 @@ Rewrite operations using AI agent tools, such as codex-cli
 """
 
 import os
+from pathlib import Path
 import re
 
 from pathspec.pathspec import PathSpec
@@ -95,12 +96,13 @@ def run_rewrite(
     prompt: str,
     input_code: TreeNode,
     extra_code: TreeNode | list[TreeNode] = [],
+    planning_files: TreeNode | None = None,
     cwd: str = '.',
     clean_cmds: list[list[str]] = [],
     codex_login: bool = False,
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
-) -> TreeNode:
+) -> tuple[TreeNode, TreeNode]:
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
         "the sandbox and could theoretically be leaked " \
@@ -121,6 +123,8 @@ def run_rewrite(
         sb.checkout(input_code)
         for n in extra_code:
             sb.checkout(n)
+        if planning_files is not None:
+            sb.checkout(planning_files)
 
         if codex_login:
             print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
@@ -166,6 +170,7 @@ def run_rewrite(
 
     output_files = {}
     json_session_files = []
+    output_plan_files = {}
     for path, node_id in raw_output_files.files.items():
         if any(path in n.files for n in extra_code):
             # This file came from the C code used for testing.  Ignore it.
@@ -181,6 +186,10 @@ def run_rewrite(
         elif path.startswith('.codex/sessions/') and path.endswith('.jsonl'):
             # This is a Codex session log file.
             json_session_files.append(node_id)
+        elif Path(path).name in ['PLAN.md', 'SAFETY_PLAN.md']:
+            # if the agent created a SAFETY_PLAN.md file, carry it over to future steps but
+            # don't include it in the main output since it's not source code.
+            output_plan_files[path] = node_id
 
     # Set the `json_session` metadata field to the session file only if it's
     # unique.  In case of ambiguity, we leave this blank, but any files that
@@ -191,6 +200,7 @@ def run_rewrite(
         json_session_node_id = FileNode.new(mvir, '').node_id()
 
     output_code = TreeNode.new(mvir, files=output_files)
+    output_plans = TreeNode.new(mvir, files=output_plan_files)
     n_op = CodexAgentOpNode.new(mvir,
         old_code = input_code.node_id(),
         new_code = output_code.node_id(),
@@ -198,9 +208,10 @@ def run_rewrite(
         exit_code = exit_code,
         raw_output_files = raw_output_files.node_id(),
         json_session = json_session_node_id,
+        planning_files = output_plans.node_id(),
         body = logs,
     )
     # Record operations and timestamps in the `op_history` reflog.
     mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
 
-    return output_code
+    return (output_code, output_plans)

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -698,6 +698,8 @@ class CodexAgentOpNode(Node):
     # JSON-formatted session log, e.g. `.codex/sessions/xxx/rollout-xxx.jsonl`
     json_session: Metadata[NodeId]
     # `body` stores the log output
+    # Agent-managed plans which tracks state across multiple loop iterations
+    planning_files: Metadata[NodeId]
 
     old_code = property(lambda self: self._metadata['old_code'])
     new_code = property(lambda self: self._metadata['new_code'])
@@ -705,6 +707,7 @@ class CodexAgentOpNode(Node):
     exit_code = property(lambda self: self._metadata['exit_code'])
     raw_output_files = property(lambda self: self._metadata['raw_output_files'])
     json_session = property(lambda self: self._metadata['json_session'])
+    planning_files = property(lambda self: self._metadata['planning_files'])
 
 class TestResultNode(Node):
     KIND = 'test_result_node'

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -116,7 +116,17 @@ New signatures:
 '''
 
 AGENT_SAFETY_PROMPT = '''
-Please refactor the Rust code in `{cargo_dir_path}` to avoid the use of `unsafe`, without changing its behavior.  First, examine the codebase to identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fileds) that uses `unsafe`, and plan how you would refactor it to make it safe.  Write this plan to `SAFETY_PLAN.md`.  Then carry out the refactor as planned.
+Please refactor the Rust code in `{cargo_dir_path}` to avoid the use of `unsafe`, without changing its behavior.
+
+You are executing one iteration of a loop that will be re-invoked on the same codebase until the unsafe count reaches zero or progress stalls. To carry state between iterations, maintain a planning file at `SAFETY_PLAN.md`:
+
+- **First, check whether `SAFETY_PLAN.md` already exists.** If it does, read it in full. It is your own notes from prior iterations. Use it to pick up where the previous run left off rather than starting over.
+- If `SAFETY_PLAN.md` does not exist, examine the codebase to identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fields) that uses `unsafe`, decide how to refactor it safely, and write that plan to `SAFETY_PLAN.md`.
+- **Before you finish, update `SAFETY_PLAN.md`** to reflect what you actually did this iteration, what is now complete, what remains, and any pitfalls or dead ends future iterations should avoid. Keep it concise — it is a working scratchpad, not a report.
+- If `SAFETY_PLAN.md` exists and all planned tasks have been completed, you should identify the next unit of code to work on and update the plan accordingly. This is a good time to trim and clean up the plan so it only contains the next steps and relevant notes. Pay close attention to pitfalls and dead ends such that future iterations do not repeat the same mistakes.
+- If a planned unit turns out to be too complex or blocked by prerequisite work, update `SAFETY_PLAN.md` to record the blocker, split the work into smaller steps, and switch to the prerequisite or smaller step. Prefer steps that directly reduce the unsafe count, but preliminary safe refactors are acceptable when they are necessary to remove unsafe code in a later iteration.
+
+Then carry out the next step of the plan.
 
 HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code.
 
@@ -1053,10 +1063,11 @@ class Workflow:
     def agent_safety(
         self,
         n_code: TreeNode,
-        n_test_code: TreeNode | None = None,
+        n_test_code: TreeNode | None,
+        n_plans: TreeNode,
         # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
-    ) -> TreeNode:
+    ) -> tuple[TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
 
@@ -1078,6 +1089,7 @@ class Workflow:
         )
         return agent.run_rewrite(cfg, mvir, prompt, n_code,
             extra_code = extra_code,
+            planning_files = n_plans,
             codex_login=self.codex_login,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
@@ -1089,7 +1101,6 @@ class Workflow:
     def agent_safety_no_tests(
         self,
         n_code: TreeNode,
-    ) -> TreeNode:
-        cfg, mvir = self.cfg, self.mvir
-        n_test_code = TreeNode.new(mvir, files={})
-        return self.agent_safety(n_code, provide_test_cmd = False)
+        n_plans: TreeNode,
+    ) -> tuple[TreeNode, TreeNode]:
+        return self.agent_safety(n_code, None, n_plans, provide_test_cmd = False)


### PR DESCRIPTION
Threads a `planning_files` `TreeNode` through the safety loop so the agent can carry `SAFETY_PLAN.md` / `PLAN.md` between iterations. Closes #110.