### PR TITLE
find_unsafe2 fixes and integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@
 FROM docker.io/rust:trixie AS tractor-crisp-user
 
 # rust-analyzer 0.0.329 (used by tools/*) requires Rust 1.93 at minimum
-RUN rustup default 1.93.1
-RUN rustup +1.93.1 component add rustfmt
+# find_unsafe2 requires a specific nightly and rustc-internal components
+RUN rustup default nightly-2026-05-11
+RUN rustup +nightly-2026-05-11 component add rustfmt rustc-dev rust-src llvm-tools
 
 RUN apt-get update
 
@@ -49,8 +50,9 @@ COPY deps/c2rust /opt/c2rust
 RUN cd /opt/c2rust \
     && uv venv \
     && uv pip install -r scripts/requirements.txt
-RUN cargo-docker-clean.sh cargo install --locked --path /opt/c2rust/c2rust
 # `cd` to resolve the `rust-toolchain.toml`.
+RUN cd /opt/c2rust \
+    && cargo-docker-clean.sh cargo install --locked --path /opt/c2rust/c2rust
 RUN cd /opt/c2rust \
     && cargo-docker-clean.sh cargo install --locked --path c2rust-refactor
 

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -330,29 +330,10 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     # `--llm-mode agent` should be handled at a higher level.
                     assert False, f'unexpected llm_mode {mode!r}'
 
-            for repair_try in range(3):
-                try:
-                    n_op_check = w.cargo_check_json_op(n_new_code)
-                    if not n_op_check.passed:
-                        n_new_code = w.llm_repair_compile(n_new_code, n_op_check)
-
-                        n_op_check = w.cargo_check_json_op(n_new_code)
-                        if not n_op_check.passed:
-                            # If we failed to fix the compile errors, don't bother
-                            # trying to run tests.  This still counts as a repair
-                            # attempt.
-                            continue
-
-                    n_op_test = w.test_op(n_new_code, n_c_code)
-                    if n_op_test.exit_code == 0:
-                        w.accept(n_new_code, ('main', 'safety', safety_try))
-                        n_code = n_new_code
-                        break
-
-                    n_new_code = w.llm_repair(n_new_code, n_op_test)
-                except CrispError as e:
-                    print(f'repair attempt {safety_try}.{repair_try} failed: {e}')
-                    traceback.print_exc()
+            n_new_code = safety_loop_validate_and_repair(w, n_new_code, n_c_code)
+            if n_new_code is not None:
+                w.accept(n_new_code, ('main', 'safety', safety_try))
+                n_code = n_new_code
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {safety_try} failed: {e}')
@@ -365,6 +346,39 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     unsafe_count = w.count_unsafe(n_code)
     print('final unsafe count = %d' % unsafe_count)
     print('final test exit code = %d' % n_op_test.exit_code)
+
+def safety_loop_validate_and_repair(w, n_new_code, n_c_code) -> TreeNode | None:
+    """
+    Validate `n_new_code`.  If it fails validation, try to repair it.  Returns
+    a version that passes validation (after zero or more repair attempts), or
+    `None` if no passing version was found.
+    """
+    for repair_try in range(3):
+        try:
+            n_op_check = w.cargo_check_json_op(n_new_code)
+            if not n_op_check.passed:
+                n_new_code = w.llm_repair_compile(n_new_code, n_op_check)
+
+                n_op_check = w.cargo_check_json_op(n_new_code)
+                if not n_op_check.passed:
+                    # If we failed to fix the compile errors, don't bother
+                    # trying to run tests.  This still counts as a repair
+                    # attempt.
+                    continue
+
+            n_op_test = w.test_op(n_new_code, n_c_code)
+            if n_op_test.exit_code == 0:
+                return n_new_code
+
+            n_new_code = w.llm_repair(n_new_code, n_op_test)
+        except CrispError as e:
+            print(f'repair attempt {safety_try}.{repair_try} failed: {e}')
+            traceback.print_exc()
+
+    # None of the new versions passed the checks.
+    return None
+
+
 
 def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -268,7 +268,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     consecutive_failures = 0
 
     for safety_try in range(llm_safety_tries):
-        unsafe_count = w.count_unsafe(n_code)
+        unsafe_count = w.count_unsafe2(n_code)
         if unsafe_count == 0:
             break
 
@@ -291,7 +291,8 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 case 'agent':
                     n_new_code = w.agent_safety(n_code, n_c_code)
                     n_op_test = w.test_op(n_new_code, n_c_code)
-                    if n_op_test.exit_code == 0:
+                    n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
+                    if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
                         w.accept(n_new_code, ('main', 'safety', safety_try))
                         n_code = n_new_code
 
@@ -305,7 +306,8 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     # the C code.
                     n_new_code = w.agent_safety_no_tests(n_code)
                     n_op_check = w.cargo_check_json_op(n_new_code)
-                    if n_op_check.passed:
+                    n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
+                    if n_op_check.passed and n_op_unsafe.exit_code == 0:
                         w.accept(n_new_code, ('main', 'safety', safety_try))
                         n_code = n_new_code
 
@@ -330,7 +332,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     # `--llm-mode agent` should be handled at a higher level.
                     assert False, f'unexpected llm_mode {mode!r}'
 
-            n_new_code = safety_loop_validate_and_repair(w, n_new_code, n_c_code)
+            n_new_code = safety_loop_validate_and_repair(w, n_code, n_new_code, n_c_code)
             if n_new_code is not None:
                 w.accept(n_new_code, ('main', 'safety', safety_try))
                 n_code = n_new_code
@@ -343,11 +345,11 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     print('final code = %s' % n_code.node_id())
     print('final c code = %s' % n_c_code.node_id())
     n_op_test = w.test_op(n_code, n_c_code)
-    unsafe_count = w.count_unsafe(n_code)
+    unsafe_count = w.count_unsafe2(n_code)
     print('final unsafe count = %d' % unsafe_count)
     print('final test exit code = %d' % n_op_test.exit_code)
 
-def safety_loop_validate_and_repair(w, n_new_code, n_c_code) -> TreeNode | None:
+def safety_loop_validate_and_repair(w, n_code, n_new_code, n_c_code) -> TreeNode | None:
     """
     Validate `n_new_code`.  If it fails validation, try to repair it.  Returns
     a version that passes validation (after zero or more repair attempts), or
@@ -355,6 +357,17 @@ def safety_loop_validate_and_repair(w, n_new_code, n_c_code) -> TreeNode | None:
     """
     for repair_try in range(3):
         try:
+            n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
+            if n_op_unsafe.exit_code != 0:
+                n_new_code = w.llm_repair_safety(n_new_code, n_op_unsafe)
+
+                n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
+                if n_op_unsafe.exit_code != 0:
+                    # If we failed to fix the unsafety, don't bother trying to
+                    # build or run tests.  This still counts as a repair
+                    # attempt.
+                    continue
+
             n_op_check = w.cargo_check_json_op(n_new_code)
             if not n_op_check.passed:
                 n_new_code = w.llm_repair_compile(n_new_code, n_op_check)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -367,10 +367,16 @@ def safety_loop_validate_and_repair(w, n_new_code, n_c_code) -> TreeNode | None:
                     continue
 
             n_op_test = w.test_op(n_new_code, n_c_code)
-            if n_op_test.exit_code == 0:
-                return n_new_code
+            if n_op_test.exit_code != 0:
+                n_new_code = w.llm_repair(n_new_code, n_op_test)
 
-            n_new_code = w.llm_repair(n_new_code, n_op_test)
+                n_op_test = w.test_op(n_new_code, n_c_code)
+                if n_op_test.exit_code != 0:
+                    continue
+
+            # All validation steps passed, so return the new version.
+            return n_new_code
+
         except CrispError as e:
             print(f'repair attempt {safety_try}.{repair_try} failed: {e}')
             traceback.print_exc()

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -87,10 +87,12 @@ def run_rewrite(
     mvir: MVIR,
     prompt: str,
     input_code: TreeNode,
-    test_code: TreeNode,
+    extra_code: TreeNode | list[TreeNode] = [],
     cwd: str = '.',
     clean_cmds: list[list[str]] = [],
     codex_login: bool = False,
+    env: dict | None = None,
+    find_unsafe2_json_dir: str | None = None,
 ) -> TreeNode:
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
@@ -102,9 +104,16 @@ def run_rewrite(
     if 'CRISP_API_KEY' in os.environ:
         print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
 
+    if isinstance(extra_code, TreeNode):
+        extra_code = [extra_code]
+
+    if env is None:
+        env = {}
+
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(input_code)
-        sb.checkout(test_code)
+        for n in extra_code:
+            sb.checkout(n)
 
         if codex_login:
             print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
@@ -121,11 +130,15 @@ def run_rewrite(
         print(codex_cmd)
         all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 
+        if 'CODEX_HOME' not in env:
+            env['CODEX_HOME'] = codex_dir
+        if find_unsafe2_json_dir is not None:
+            env['FIND_UNSAFE2_JSON_DIR'] = sb.join(find_unsafe2_json_dir)
+
         exit_code = 0
         logs = b''
         for cmd in all_cmds:
-            exit_code, logs2 = sb.run(cmd, cwd=cwd, stream=True,
-                                      env={"CODEX_HOME": codex_dir})
+            exit_code, logs2 = sb.run(cmd, cwd=cwd, stream=True, env=env)
             logs += logs2
 
             # TODO: ensure API key doesn't get included in the AgentOpNode
@@ -147,7 +160,7 @@ def run_rewrite(
     output_files = {}
     json_session_files = []
     for path, node_id in raw_output_files.files.items():
-        if path in test_code.files:
+        if any(path in n.files for n in extra_code):
             # This file came from the C code used for testing.  Ignore it.
             pass
         elif path in input_code.files:

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -469,8 +469,6 @@ def _check_unsafe2_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
         cmd = cmd,
         exit_code = exit_code,
     )
-    if exit_code != 0:
-        raise CrispError('check_unsafe2 failed', n_op)
     return n_op
 
 def check_unsafe2(cfg: Config, mvir: MVIR,

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -15,7 +15,7 @@ from .mvir import (
     MVIR, NodeId, Node, FileNode, TreeNode, TestResultNode,
     CompileCommandsOpNode, FindUnsafeAnalysisNode, CargoCheckJsonAnalysisNode,
     InlineErrorsOpNode, DefNode, CrateNode, SplitOpNode, MergeOpNode,
-    RelatedDeclsOpNode,
+    RelatedDeclsOpNode, FindUnsafe2AnalysisNode,
 )
 from .sandbox import Sandbox, run_sandbox
 
@@ -379,13 +379,12 @@ def _find_unsafe_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
     exit_code, logs = sb.run(cmd_wrapped)
 
     if exit_code == 0:
-        if isinstance(logs, bytes):
-            logs = logs.decode()
-
         json = sb.commit_file('unsafe.json').body_str()
     else:
         json = ''
-        crate_out = CrateNode.new(mvir, defs = {})
+
+    if isinstance(logs, bytes):
+        logs = logs.decode()
 
     n_op = FindUnsafeAnalysisNode.new(
         mvir,
@@ -401,10 +400,56 @@ def _find_unsafe_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
         raise CrispError('find_unsafe failed', n_op)
     return n_op
 
-def find_unsafe(cfg: Config, mvir: MVIR, code: TreeNode) -> CompileCommandsOpNode:
+def find_unsafe(cfg: Config, mvir: MVIR, code: TreeNode) -> FindUnsafeAnalysisNode:
     with run_sandbox(cfg, mvir) as sb:
         cmd = ['find-unsafe', '--dir', sb.join('.')]
         n_op = _find_unsafe_impl(cfg, mvir, sb, code, cmd)
+    return n_op
+
+
+UNSAFE_JSON_DIR = 'unsafe_json'
+
+@analysis
+def _find_unsafe2_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
+        code: TreeNode, cmd: list[str]) -> FindUnsafe2AnalysisNode:
+    sb.checkout(code)
+
+    cmd_wrapped = ['sh', '-c', shlex.join(cmd)]
+    exit_code, logs = sb.run(cmd_wrapped)
+
+    if exit_code == 0:
+        if isinstance(logs, bytes):
+            logs = logs.decode()
+
+        unsafe_json = sb.commit_dir(UNSAFE_JSON_DIR)
+    else:
+        unsafe_json = TreeNode.new(mvir, files = {})
+
+    n_op = FindUnsafe2AnalysisNode.new(
+        mvir,
+        body = logs,
+        code = code.node_id(),
+        cmd = cmd,
+        exit_code = exit_code,
+        unsafe_json = unsafe_json.node_id(),
+    )
+    if exit_code != 0:
+        raise CrispError('find_unsafe2 failed', n_op)
+    return n_op
+
+def find_unsafe2(cfg: Config, mvir: MVIR, code: TreeNode) -> FindUnsafe2AnalysisNode:
+    cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
+    cargo_toml_path = os.path.join(cargo_dir, 'Cargo.toml')
+
+    with run_sandbox(cfg, mvir) as sb:
+        cmd = [
+            'env',
+            f'FIND_UNSAFE2_SRC_DIR={sb.join(cargo_dir)}',
+            f'FIND_UNSAFE2_JSON_DIR={sb.join("unsafe_json")}',
+            'cargo', 'find-unsafe2',
+            '--manifest-path', sb.join(cargo_toml_path),
+        ]
+        n_op = _find_unsafe2_impl(cfg, mvir, sb, code, cmd)
     return n_op
 
 

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -15,7 +15,7 @@ from .mvir import (
     MVIR, NodeId, Node, FileNode, TreeNode, TestResultNode,
     CompileCommandsOpNode, FindUnsafeAnalysisNode, CargoCheckJsonAnalysisNode,
     InlineErrorsOpNode, DefNode, CrateNode, SplitOpNode, MergeOpNode,
-    RelatedDeclsOpNode, FindUnsafe2AnalysisNode,
+    RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
 )
 from .sandbox import Sandbox, run_sandbox
 
@@ -450,6 +450,42 @@ def find_unsafe2(cfg: Config, mvir: MVIR, code: TreeNode) -> FindUnsafe2Analysis
             '--manifest-path', sb.join(cargo_toml_path),
         ]
         n_op = _find_unsafe2_impl(cfg, mvir, sb, code, cmd)
+    return n_op
+
+@analysis
+def _check_unsafe2_impl(cfg: Config, mvir: MVIR, sb: Sandbox,
+        code: TreeNode, unsafe_json: TreeNode, cmd: list[str]) -> CheckUnsafe2AnalysisNode:
+    sb.checkout(code)
+    sb.checkout(unsafe_json)
+
+    cmd_wrapped = ['sh', '-c', shlex.join(cmd)]
+    exit_code, logs = sb.run(cmd_wrapped)
+
+    n_op = CheckUnsafe2AnalysisNode.new(
+        mvir,
+        body = logs,
+        code = code.node_id(),
+        unsafe_json = unsafe_json.node_id(),
+        cmd = cmd,
+        exit_code = exit_code,
+    )
+    if exit_code != 0:
+        raise CrispError('check_unsafe2 failed', n_op)
+    return n_op
+
+def check_unsafe2(cfg: Config, mvir: MVIR,
+        code: TreeNode, unsafe_json: TreeNode) -> CheckUnsafe2AnalysisNode:
+    cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
+    cargo_toml_path = os.path.join(cargo_dir, 'Cargo.toml')
+
+    with run_sandbox(cfg, mvir) as sb:
+        cmd = [
+            'env',
+            f'FIND_UNSAFE2_JSON_DIR={sb.join("unsafe_json")}',
+            'cargo', 'check-unsafe2',
+            '--manifest-path', sb.join(cargo_toml_path),
+        ]
+        n_op = _check_unsafe2_impl(cfg, mvir, sb, code, unsafe_json, cmd)
     return n_op
 
 

--- a/crisp/error.py
+++ b/crisp/error.py
@@ -13,6 +13,10 @@ class CrispError(Exception):
     def __init__(self, message, node_id = None):
         super().__init__(message)
         self.message = message
+
+        from .mvir import Node
+        if isinstance(node_id, Node):
+            node_id = node_id.node_id()
         self.node_id = node_id
 
     def __str__(self):

--- a/crisp/git.py
+++ b/crisp/git.py
@@ -104,6 +104,7 @@ def commit_tree(mvir: MVIR, repo: pygit2.Repository, tree: TreeNode,
     git_tree = build_tree(tree_files)
 
     meta = []
+    meta.append('tree node id = %s' % tree.node_id())
     for ie in mvir.index(tree.node_id()):
         n = mvir.node(ie.node_id)
         if isinstance(n, mvir_module.TestResultNode):

--- a/crisp/git.py
+++ b/crisp/git.py
@@ -119,6 +119,13 @@ def commit_tree(mvir: MVIR, repo: pygit2.Repository, tree: TreeNode,
                 len(file_info['macro_definitions_containing_unsafe'])
                 for file_info in j_unsafe.values())
             meta.append('unsafe count = %d' % unsafe_count)
+        elif isinstance(n, mvir_module.FindUnsafe2AnalysisNode):
+            n_json = mvir.node(n.unsafe_json)
+            total = 0
+            for n_json_file_id in n_json.files.values():
+                n_json_file = mvir.node(n_json_file_id)
+                total += n_json_file.body_json()['total_unsafe']
+            meta.append('unsafe count (v2) = %d' % total)
 
     if len(meta) > 0:
         msg = msg + '\n\n' + '\n'.join(meta)

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -777,6 +777,20 @@ class FindUnsafe2AnalysisNode(Node):
     exit_code = property(lambda self: self._metadata['exit_code'])
     unsafe_json = property(lambda self: self._metadata['unsafe_json'])
 
+class CheckUnsafe2AnalysisNode(Node):
+    KIND = 'check_unsafe2_analysis'
+    code: Metadata[NodeId]
+    # `TreeNode` containing the previous JSON files to compare against
+    unsafe_json: Metadata[NodeId]
+    cmd: Metadata[list[str]]
+    exit_code: Metadata[int]
+    # `body` stores the log output
+
+    code = property(lambda self: self._metadata['code'])
+    unsafe_json = property(lambda self: self._metadata['unsafe_json'])
+    cmd = property(lambda self: self._metadata['cmd'])
+    exit_code = property(lambda self: self._metadata['exit_code'])
+
 class EditOpNode(Node):
     KIND = 'edit_op'
     old_code: Metadata[NodeId]
@@ -904,6 +918,7 @@ NODE_CLASSES = [
     InlineErrorsOpNode,
     FindUnsafeAnalysisNode,
     FindUnsafe2AnalysisNode,
+    CheckUnsafe2AnalysisNode,
     EditOpNode,
 
     DefNode,

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -763,6 +763,20 @@ class FindUnsafeAnalysisNode(Node):
     exit_code = property(lambda self: self._metadata['exit_code'])
     stderr = property(lambda self: self._metadata['stderr'])
 
+class FindUnsafe2AnalysisNode(Node):
+    KIND = 'find_unsafe2_analysis'
+    code: Metadata[NodeId]
+    cmd: Metadata[list[str]]
+    exit_code: Metadata[int]
+    # `TreeNode` containing the generated JSON files
+    unsafe_json: Metadata[NodeId]
+    # `body` stores the log output
+
+    code = property(lambda self: self._metadata['code'])
+    cmd = property(lambda self: self._metadata['cmd'])
+    exit_code = property(lambda self: self._metadata['exit_code'])
+    unsafe_json = property(lambda self: self._metadata['unsafe_json'])
+
 class EditOpNode(Node):
     KIND = 'edit_op'
     old_code: Metadata[NodeId]
@@ -889,6 +903,7 @@ NODE_CLASSES = [
     CargoCheckJsonAnalysisNode,
     InlineErrorsOpNode,
     FindUnsafeAnalysisNode,
+    FindUnsafe2AnalysisNode,
     EditOpNode,
 
     DefNode,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -81,6 +81,22 @@ Compiler logs:
 ```
 '''
 
+LLM_REPAIR_SAFETY_PROMPT = '''
+A recent change to this Rust code added new unsafety that wasn't present
+before.  See the report below and fix the indicated sources of unsafety.  Avoid
+adding new unsafe code, as it will be rejected by the same check.
+
+{output_instructions}
+
+{input_files}
+
+Unsafety report:
+
+```
+{logs}
+```
+'''
+
 LLM_PROMPT_REPAIR_CALL_SITES = '''
 The file `ffi.rs` below contains FFI wrapper functions, which expose various Rust functions to C. The signatures of the underlying Rust functions have changed; please update the wrappers to match.
 
@@ -106,18 +122,11 @@ HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry poin
 
 {after_refactoring_instruction}
 
-You can measure the amount of unsafe code remaining using this command:
+Your changes must not introduce new unsafe code within implementation functions.  You can check your work using this command:
 ```sh
-find-unsafe --dir {cargo_dir_path} \
-    | jq '[to_entries.[].value | (.internal_unsafe_fns | length) + (.fns_containing_unsafe | length) + (.statics_containing_unsafe | length) + (.mutable_statics | length) + (.global_macro_invocations_containing_unsafe | length) + (.macro_definitions_containing_unsafe | length)] | add'
+cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
-This counts:
-- All non-FFI-related functions that are either `unsafe fn` or contain unsafe code interally.
-- All static items that contain unsafe.
-- All static mutable items, whether or not they contain unsafe.
-- All macro definitions and invocations that contain unsafe.
-
-Your goal is to reduce this metric from its initial value of {initial_unsafe_count}. In rare cases it may be necessary to add new unsafe code, but you should always aim to remove more unsafe code than you add.
+This will report an error for any unsafe code that was improperly added during your edits.
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''
@@ -736,15 +745,18 @@ class Workflow:
 
     @step
     def count_unsafe2(self, n_code: TreeNode) -> int:
-        mvir = self.mvir
-        n_op = self.find_unsafe2_op(n_code)
-        n_json = mvir.node(n_op.unsafe_json)
+        n_json = self.find_unsafe2_json(n_code)
         total = 0
         for n_json_file_id in n_json.files.values():
-            n_json_file = mvir.node(n_json_file_id)
+            n_json_file = self.mvir.node(n_json_file_id)
             total += n_json_file.body_json()['total_unsafe']
         print('%d unsafe operations remaining' % total)
         return total
+
+    @step
+    def find_unsafe2_json(self, n_code: TreeNode) -> TreeNode:
+        n_op = self.find_unsafe2_op(n_code)
+        return self.mvir.node(n_op.unsafe_json)
 
     @step
     def find_unsafe2_op(self, n_code: TreeNode) -> FindUnsafe2AnalysisNode:
@@ -754,6 +766,13 @@ class Workflow:
     def check_unsafe2_op(
             self, n_code: TreeNode, n_unsafe_json: TreeNode) -> CheckUnsafe2AnalysisNode:
         return analysis.check_unsafe2(self.cfg, self.mvir, n_code, n_unsafe_json)
+
+    @step
+    def compare_unsafe2_op(
+            self, n_old_code: TreeNode, n_new_code: TreeNode) -> CheckUnsafe2AnalysisNode:
+        n_find_op = self.find_unsafe2_op(n_old_code)
+        n_unsafe_json = self.mvir.node(n_find_op.unsafe_json)
+        return self.check_unsafe2_op(n_new_code, n_unsafe_json)
 
     @step
     def llm_safety(
@@ -811,6 +830,27 @@ class Workflow:
                 self.cfg, self.mvir, LLM_REPAIR_COMPILE_PROMPT, n_code,
                 glob_filter = self.cfg.src_globs,
                 format_kwargs = {'stderr': stderr},
+                think = True)
+
+    @step
+    def llm_repair_safety(
+        self,
+        n_code: TreeNode,
+        n_op_check: CargoCheckJsonAnalysisNode,
+    ) -> TreeNode:
+        n_new_code, n_op_llm = self.llm_repair_safety_op(n_code, n_op_check)
+        return n_new_code
+
+    @step
+    def llm_repair_safety_op(
+        self,
+        n_code: TreeNode,
+        n_op_check: CheckUnsafe2AnalysisNode,
+    ) -> tuple[TreeNode, LlmOpNode]:
+        return llm.run_rewrite(
+                self.cfg, self.mvir, LLM_REPAIR_SAFETY_PROMPT, n_code,
+                glob_filter = self.cfg.src_globs,
+                format_kwargs = {'logs': n_op_check.body_str()},
                 think = True)
 
     @step
@@ -1000,7 +1040,7 @@ class Workflow:
     def agent_safety(
         self,
         n_code: TreeNode,
-        n_test_code: TreeNode,
+        n_test_code: TreeNode | None = None,
         # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
     ) -> TreeNode:
@@ -1013,16 +1053,24 @@ class Workflow:
         else:
             after_refactoring_instruction = AGENT_AFTER_REFACTORING_BUILD
 
+        extra_code = [
+            self.find_unsafe2_json(n_code),
+        ]
+        if n_test_code is not None:
+            extra_code.append(n_test_code)
+
         prompt = AGENT_SAFETY_PROMPT.format(
             cargo_dir_path = cargo_dir,
-            initial_unsafe_count = self.count_unsafe(n_code),
             after_refactoring_instruction = after_refactoring_instruction,
         )
-        return agent.run_rewrite(cfg, mvir, prompt, n_code, n_test_code,
+        return agent.run_rewrite(cfg, mvir, prompt, n_code,
+            extra_code = extra_code,
             codex_login=self.codex_login,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
-            ])
+            ],
+            find_unsafe2_json_dir = analysis.UNSAFE_JSON_DIR,
+        )
 
     @step
     def agent_safety_no_tests(
@@ -1031,4 +1079,4 @@ class Workflow:
     ) -> TreeNode:
         cfg, mvir = self.cfg, self.mvir
         n_test_code = TreeNode.new(mvir, files={})
-        return self.agent_safety(n_code, n_test_code, provide_test_cmd = False)
+        return self.agent_safety(n_code, provide_test_cmd = False)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -735,6 +735,18 @@ class Workflow:
         return analysis.find_unsafe(self.cfg, self.mvir, n_code)
 
     @step
+    def count_unsafe2(self, n_code: TreeNode) -> int:
+        mvir = self.mvir
+        n_op = self.find_unsafe2_op(n_code)
+        n_json = mvir.node(n_op.unsafe_json)
+        total = 0
+        for n_json_file_id in n_json.files.values():
+            n_json_file = mvir.node(n_json_file_id)
+            total += n_json_file.body_json()['total_unsafe']
+        print('%d unsafe operations remaining' % total)
+        return total
+
+    @step
     def find_unsafe2_op(self, n_code: TreeNode) -> FindUnsafe2AnalysisNode:
         return analysis.find_unsafe2(self.cfg, self.mvir, n_code)
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -18,7 +18,7 @@ from .mvir import (
     LlmOpNode, TestResultNode, FindUnsafeAnalysisNode, SplitFfiOpNode,
     CargoCheckJsonAnalysisNode, EditOpNode, WorkflowStepInputsNode,
     WorkflowStepNode, SplitOpNode, MergeOpNode, CrateNode, DefNode,
-    RelatedDeclsOpNode,
+    RelatedDeclsOpNode, FindUnsafe2AnalysisNode,
 )
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir
@@ -733,6 +733,10 @@ class Workflow:
     @step
     def find_unsafe_op(self, n_code: TreeNode) -> FindUnsafeAnalysisNode:
         return analysis.find_unsafe(self.cfg, self.mvir, n_code)
+
+    @step
+    def find_unsafe2_op(self, n_code: TreeNode) -> FindUnsafe2AnalysisNode:
+        return analysis.find_unsafe2(self.cfg, self.mvir, n_code)
 
     @step
     def llm_safety(

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -18,7 +18,7 @@ from .mvir import (
     LlmOpNode, TestResultNode, FindUnsafeAnalysisNode, SplitFfiOpNode,
     CargoCheckJsonAnalysisNode, EditOpNode, WorkflowStepInputsNode,
     WorkflowStepNode, SplitOpNode, MergeOpNode, CrateNode, DefNode,
-    RelatedDeclsOpNode, FindUnsafe2AnalysisNode,
+    RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
 )
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir
@@ -737,6 +737,11 @@ class Workflow:
     @step
     def find_unsafe2_op(self, n_code: TreeNode) -> FindUnsafe2AnalysisNode:
         return analysis.find_unsafe2(self.cfg, self.mvir, n_code)
+
+    @step
+    def check_unsafe2_op(
+            self, n_code: TreeNode, n_unsafe_json: TreeNode) -> CheckUnsafe2AnalysisNode:
+        return analysis.check_unsafe2(self.cfg, self.mvir, n_code, n_unsafe_json)
 
     @step
     def llm_safety(

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -9,6 +9,7 @@ unsafe extern "C" {
     fn puts(s: *const u8);
 }
 fn fake_safe_puts(s: *const u8) {
+    // Error: introduced a new function containing unsafe.
     unsafe {
         puts(s);
     }
@@ -18,6 +19,7 @@ fn f2() {
 }
 
 fn deref_ptr<T: Copy>(p: *const T) -> T {
+    // Error: introduced a new function containing unsafe.
     unsafe { *p }
 }
 fn f3(p: *const i32) -> i32 {
@@ -34,4 +36,27 @@ fn f4() -> i32 {
 
 fn f6(r: &i32) -> i32 {
     *r
+}
+
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn ffi1(p: *const i32) -> i32 {
+    // Added a second pointer dereference, but no error because this is an FFI entry point.
+    unsafe { *p + *p }
+}
+
+#[unsafe(no_mangle)]
+static FFI2: i32 = {
+    // Added a new raw pointer dereference.  Even though this static is an FFI entry point, we
+    // still disallow unsafe operations in entry-point statics, as described in a comment in
+    // `is_ffi_entry_point`.
+    let x = 0;
+    let p = &raw const x;
+    unsafe { *p }
+};
+
+// Error: converted non-FFI function into FFI entry point.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
+    unsafe { *p }
 }

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -15,7 +15,7 @@ fn f2() {
 }
 
 unsafe fn f3(p: *const i32) -> i32 {
-    *p
+    unsafe { *p }
 }
 
 static mut S: i32 = 123;
@@ -41,4 +41,17 @@ fn f5b(x: i32) -> [u8; 4] {
 
 fn f6(r: &i32) -> i32 {
     unsafe { f3(r) }
+}
+
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn ffi1(p: *const i32) -> i32 {
+    unsafe { *p }
+}
+
+#[unsafe(no_mangle)]
+static FFI2: i32 = 0;
+
+unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
+    unsafe { *p }
 }

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -21,7 +21,7 @@ use find_unsafe2::{self, Outputs, FunctionOutputs};
 /// Prints an error for each thing in `new` that doesn't appear in `old`, and returns `false` if it
 /// found any such things.
 fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
-    let Outputs { ref fns } = *new;
+    let Outputs { total_unsafe: _, ref fns } = *new;
     let mut ok = true;
 
     let empty_fn = FunctionOutputs {

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -30,6 +30,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
         uses_static_mut: Default::default(),
         uses_union_field: Default::default(),
         uses_foreign_fn: Default::default(),
+        is_ffi_entry_point: false,
     };
     for (fn_name, new_fn) in fns {
         let old_fn = old.fns.get(fn_name).unwrap_or(&empty_fn);
@@ -40,9 +41,15 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
 }
 
 fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutputs) -> bool {
+    if old.is_ffi_entry_point {
+        // Allow increasing unsafe within FFI entry points.
+        return true;
+    }
+
     let FunctionOutputs {
         derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
+        is_ffi_entry_point,
     } = *new;
     let mut ok = true;
 
@@ -57,6 +64,9 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
         |k| format!("{name}: uses of union field {k}"));
     ok &= check_count_map(&old.uses_foreign_fn, uses_foreign_fn,
         |k| format!("{name}: uses of foreign fn {k}"));
+
+    ok &= check_bad_flag(old.is_ffi_entry_point, is_ffi_entry_point,
+        || format!("{name}: FFI export flag"));
 
     ok
 }
@@ -74,9 +84,20 @@ fn check_count_map<K: Hash + Eq>(
     ok
 }
 
+/// Check a numeric "badness" count.  If the number increased, report an error.
 fn check_count(old: usize, new: usize, desc: impl FnOnce() -> String) -> bool {
     if new > old {
         println!("{} increased: {old} -> {new}", desc());
+        false
+    } else {
+        true
+    }
+}
+
+/// Check the state of a "bad" flag.  If it changed from `false` to `true`, report an error.
+fn check_bad_flag(old: bool, new: bool, desc: impl FnOnce() -> String) -> bool {
+    if !old && new {
+        println!("{} changed: false -> true", desc());
         false
     } else {
         true

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -123,7 +123,9 @@ fn main() {
 
     let args = env::args().collect::<Vec<_>>();
     let r = rustc_public::run_with_tcx!(&args[1..], |tcx| {
-        let json_path = json_dir.join(format!("{}.json", rustc_public::local_crate().name));
+        let crate_name = rustc_public::local_crate().name;
+
+        let json_path = json_dir.join(format!("{crate_name}.json"));
         if !fs::exists(&json_path).unwrap() {
             return ControlFlow::<(), ()>::Continue(());
         }

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -24,7 +24,12 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
     let Outputs { total_unsafe: _, ref fns } = *new;
     let mut ok = true;
 
+    // We use this default `FunctionOutputs` as the `old_fn` for items that are defined in `new`
+    // but not in `old`.  All unsafety and progress metrics are set to zero, so if the agent adds a
+    // new unsafe function that wasn't present before, we detect that as a regression.
     let empty_fn = FunctionOutputs {
+        is_unsafe_fn: false,
+        is_mut_static: false,
         derefs_raw_ptr: 0,
         calls_unsafe: 0,
         uses_static_mut: Default::default(),
@@ -47,11 +52,16 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
     }
 
     let FunctionOutputs {
-        derefs_raw_ptr, calls_unsafe,
+        is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
         is_ffi_entry_point,
     } = *new;
     let mut ok = true;
+
+    ok &= check_bad_flag(old.is_unsafe_fn, is_unsafe_fn,
+        || format!("{name}: `unsafe` qualifier"));
+    ok &= check_bad_flag(old.is_mut_static, is_mut_static,
+        || format!("{name}: `mut` qualifier"));
 
     ok &= check_count(old.derefs_raw_ptr, derefs_raw_ptr,
         || format!("{name}: raw pointer derefs"));

--- a/tools/find_unsafe2/src/bin/find_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/find_unsafe2.rs
@@ -29,6 +29,17 @@ fn main() {
 
     let args = env::args().collect::<Vec<_>>();
     let r = rustc_public::run_with_tcx!(&args[1..], |tcx| {
+        let crate_name = rustc_public::local_crate().name;
+
+        if crate_name == "build_script_build" {
+            // Special case: cargo compiles all build scripts with this name, making no distinction
+            // between build scripts from different crates.  This means `check_unsafe2` may end up
+            // comparing one crate's code to a different crate's JSON, causing spurious errors.  We
+            // skip build scripts here, so they aren't considered by `check_unsafe2` and also don't
+            // contribute to the project's overall unsafe count.
+            return ControlFlow::<(), ()>::Continue(());
+        }
+
         let mut found_src = false;
         let mut files_seen = HashSet::new();
         let items = rustc_public::all_local_items();
@@ -48,7 +59,7 @@ fn main() {
         if found_src {
             let out = find_unsafe2::process(tcx);
 
-            let out_path = json_dir.join(format!("{}.json", rustc_public::local_crate().name));
+            let out_path = json_dir.join(format!("{crate_name}.json"));
             serde_json::to_writer(
                 File::create(&out_path).unwrap(),
                 &out,

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -8,8 +8,9 @@ extern crate rustc_driver;
 
 use std::collections::HashMap;
 use indexmap::IndexMap;
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::ty::TyCtxt;
-use rustc_public::{DefId, CrateDef};
+use rustc_public::{DefId, CrateDef, CrateItem, ItemKind};
 use rustc_public::mir::{
     Body, Terminator, TerminatorKind, Place, Rvalue, Operand, Safety, FieldIdx, ProjectionElem,
     AggregateKind,
@@ -179,6 +180,10 @@ pub struct FunctionOutputs {
     /// Progress: function mentions imported `extern` `fn`s.
     pub uses_foreign_fn: IndexMap<String, usize>,
     // TODO: Progress: function signature type contains raw pointers.
+
+    /// Whether this function is an FFI entry point.  Specifically, this is set when the function
+    /// has the `#[no_mangle]` or `#[export_name = ...]` attribute.
+    pub is_ffi_entry_point: bool,
 }
 
 
@@ -215,6 +220,27 @@ pub fn process(tcx: TyCtxt) -> Outputs {
         }
     };
 
+    let is_ffi_entry_point = move |item: CrateItem| {
+        if item.is_foreign_item() {
+            // FFI imports are not entry points.
+            return false;
+        }
+        if !matches!(item.kind(), ItemKind::Fn /* | ItemKind::Static*/) {
+            // Only `fn`s and `static`s can be exported.
+            //
+            // However, since statics have no inputs (only outputs), we expect they should almost
+            // never need unsafe code internally.  So we don't apply the entry-point flag, which
+            // allows internal unsafe code.
+            //
+            // TODO: do set the flag on statics (for accuracy) but filter them out elsewhere
+            return false;
+        }
+        let internal_def_id = rustc_internal::internal::<DefId>(tcx, item.0);
+        let attrs = tcx.codegen_fn_attrs(internal_def_id);
+        attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE)
+            || attrs.symbol_name.is_some()
+    };
+
     let mut out = Outputs {
         fns: IndexMap::new(),
     };
@@ -237,6 +263,8 @@ pub fn process(tcx: TyCtxt) -> Outputs {
                 uses_foreign_fn: v.uses_fns.iter().filter_map(|(&fd, &count)| {
                     is_fn_foreign(fd).then(|| (fd.name(), count))
                 }).collect(),
+
+                is_ffi_entry_point: is_ffi_entry_point(item),
             };
             let old = out.fns.insert(key, value);
             assert!(old.is_none(), "duplicate entry for {:?}", item.name());

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -147,6 +147,11 @@ impl Visitor<'_> for FunctionVisitor<'_> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Outputs {
+    /// Sum of all unsafe counts from all functions and items, except for FFI entry points.
+    ///
+    /// This includes only unsafety metrics, not progress metrics.
+    pub total_unsafe: usize,
+
     pub fns: IndexMap<String, FunctionOutputs>,
 
     // TODO: Unsafety: crate implements `unsafe trait`s.
@@ -184,6 +189,24 @@ pub struct FunctionOutputs {
     /// Whether this function is an FFI entry point.  Specifically, this is set when the function
     /// has the `#[no_mangle]` or `#[export_name = ...]` attribute.
     pub is_ffi_entry_point: bool,
+}
+
+impl FunctionOutputs {
+    fn total_unsafe(&self) -> usize {
+        let FunctionOutputs {
+            derefs_raw_ptr, calls_unsafe,
+            ref uses_static_mut, ref uses_union_field,
+            // Progress, not safety
+            uses_foreign_fn: _,
+            // Other
+            is_ffi_entry_point: _,
+        } = *self;
+
+        derefs_raw_ptr
+            + calls_unsafe
+            + uses_static_mut.values().copied().sum::<usize>()
+            + uses_union_field.values().copied().sum::<usize>()
+    }
 }
 
 
@@ -242,6 +265,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
     };
 
     let mut out = Outputs {
+        total_unsafe: 0,
         fns: IndexMap::new(),
     };
     for item in items {
@@ -266,6 +290,9 @@ pub fn process(tcx: TyCtxt) -> Outputs {
 
                 is_ffi_entry_point: is_ffi_entry_point(item),
             };
+            if !value.is_ffi_entry_point {
+                out.total_unsafe += value.total_unsafe();
+            }
             let old = out.fns.insert(key, value);
             assert!(old.is_none(), "duplicate entry for {:?}", item.name());
         }

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -162,6 +162,14 @@ pub struct Outputs {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionOutputs {
+    /// Unsafety: the function itself is unsafe.
+    ///
+    /// It's actually safe to define an `unsafe fn`, but we count this in our unsafety metrics so
+    /// the CRISP loop won't stop until all `unsafe fn`s are cleaned up or removed, including ones
+    /// that are never called.
+    pub is_unsafe_fn: bool,
+    /// Unsafety: this "function" is actually a static initializer, and the static is mutable.
+    pub is_mut_static: bool,
     /// Unsafety: function dereferences raw pointers.
     pub derefs_raw_ptr: usize,
     /// Unsafety: function calls `unsafe fn`s.
@@ -194,7 +202,7 @@ pub struct FunctionOutputs {
 impl FunctionOutputs {
     fn total_unsafe(&self) -> usize {
         let FunctionOutputs {
-            derefs_raw_ptr, calls_unsafe,
+            is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
             ref uses_static_mut, ref uses_union_field,
             // Progress, not safety
             uses_foreign_fn: _,
@@ -202,7 +210,9 @@ impl FunctionOutputs {
             is_ffi_entry_point: _,
         } = *self;
 
-        derefs_raw_ptr
+        is_unsafe_fn as usize
+            + is_mut_static as usize
+            + derefs_raw_ptr
             + calls_unsafe
             + uses_static_mut.values().copied().sum::<usize>()
             + uses_union_field.values().copied().sum::<usize>()
@@ -243,6 +253,20 @@ pub fn process(tcx: TyCtxt) -> Outputs {
         }
     };
 
+    let is_unsafe_fn = move |item: CrateItem| {
+        if item.kind() != ItemKind::Fn {
+            return false;
+        }
+        let fd = FnDef(item.0);
+        fd.fn_sig().value.safety == Safety::Unsafe
+    };
+
+    let is_mut_static = move |item: CrateItem| {
+        let Ok(sd) = StaticDef::try_from(item) else { return false };
+        let internal_def_id = rustc_internal::internal::<DefId>(tcx, sd.0);
+        tcx.is_mutable_static(internal_def_id)
+    };
+
     let is_ffi_entry_point = move |item: CrateItem| {
         if item.is_foreign_item() {
             // FFI imports are not entry points.
@@ -275,6 +299,8 @@ pub fn process(tcx: TyCtxt) -> Outputs {
 
             let key: String = item.name();
             let value = FunctionOutputs {
+                is_unsafe_fn: is_unsafe_fn(item),
+                is_mut_static: is_mut_static(item),
                 derefs_raw_ptr: v.derefs_raw_ptr,
                 calls_unsafe: v.calls_unsafe,
                 uses_static_mut: v.uses_statics.iter().filter_map(|(&sd, &count)| {

--- a/tools/find_unsafe2/tests/example.rs
+++ b/tools/find_unsafe2/tests/example.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
 use insta;
 
 #[test]
@@ -21,6 +21,7 @@ fn run_example() {
         .args(["--edition", "2024"])
         .args(["--out-dir", env!("CARGO_TARGET_TMPDIR")])
         .env("FIND_UNSAFE2_JSON_DIR", env!("CARGO_TARGET_TMPDIR"))
+        .stderr(Stdio::inherit())
         .output().unwrap();
     assert!(!output.status.success(), "subcommand succeeded unexpectedly");
     let stdout = String::from_utf8(output.stdout).unwrap();

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -5,3 +5,5 @@ expression: stdout
 lib::fake_safe_puts: unsafe function calls increased: 0 -> 1
 lib::fake_safe_puts: uses of foreign fn lib::puts increased: 0 -> 1
 lib::deref_ptr: raw pointer derefs increased: 0 -> 1
+lib::FFI2: raw pointer derefs increased: 0 -> 1
+lib::non_ffi3: FFI export flag changed: false -> true

--- a/tools/install-all.sh
+++ b/tools/install-all.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 dir=$(dirname "$0")
 cargo install --locked --path "$dir"/find_unsafe
+cargo install --locked --path "$dir"/find_unsafe2
+cargo install --locked --path "$dir"/find_unsafe2/cargo_subcommands
 cargo install --locked --path "$dir"/merge_rust
 cargo install --locked --path "$dir"/related_decls
 cargo install --locked --path "$dir"/split_ffi_entry_points


### PR DESCRIPTION
This branch replaces `find_unsafe` with `find_unsafe2` in the CRISP loop.  It also makes the checking stricter: previously, CRISP would accept changes that regress the unsafe count and bail out if too many such changes occurred in a row; with this branch, CRISP instead rejects the change if it adds any unsafe that wasn't previously present.  Instead of only considering the aggregate total, CRISP now checks on a per-function basis (using the `check_unsafe2` helper tool).  This means a change that removes three raw pointer derefs by replacing them with a single `deref_ptr` helper function will be rejected, even though the aggregate count decreased, because newly-added functions are not allowed to contain unsafe.  (Specifically, if `check_unsafe2` doesn't find an old version of the function, it assumes all metrics are zero and forbids any increase.)

This doesn't add an option to restore the old behavior, but if you need it for experiments in the short term, try reverting 51706be3933af5be8c15ddf0611803e01a99d348