### PR TITLE
find_unsafe: report unsafe inside impl and trait methods

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "ciborium",
  "clap",
  "proc-macro2",
+ "quote",
  "serde",
  "serde_json",
  "syn",

--- a/tools/find_unsafe/Cargo.toml
+++ b/tools/find_unsafe/Cargo.toml
@@ -10,3 +10,4 @@ serde.workspace = true
 serde_json.workspace = true
 clap.workspace = true
 proc-macro2.workspace = true
+quote.workspace = true

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -425,6 +425,7 @@ mod tests {
 
         assert_eq!(internal_unsafe_fns, [
             "f",
+            "H::i",
         ]);
 
         assert_eq!(fns_containing_unsafe, [
@@ -433,6 +434,10 @@ mod tests {
             "f",
             "d",
             "g",
+            "H::h",
+            "H::i",
+            "J::k",
+            "<H as J>::j",
         ].into_iter().map(String::from).collect());
     }
 

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -4,8 +4,12 @@ use std::io::{self, Read};
 use std::path::{self, PathBuf};
 use clap::Parser;
 use proc_macro2::{TokenStream, TokenTree};
+use quote::ToTokens;
 use serde::Serialize;
-use syn::{self, Attribute, ExprUnsafe, Ident, ItemFn, ItemMacro, ItemStatic, Macro, Meta, Path, StaticMutability};
+use syn::{
+    self, Attribute, ExprUnsafe, ImplItemFn, ItemFn, ItemImpl, ItemMacro, ItemStatic, ItemTrait,
+    Macro, Meta, Path, StaticMutability, TraitItemFn,
+};
 use syn::visit::{self, Visit};
 
 // Include test files to ensure they compile.
@@ -47,10 +51,10 @@ fn is_link_attr_path(path: &Path) -> bool {
     }
 }
 
-/// Returns `true` if `f` is exported to other compilation units using a link attribute such as
-/// `#[no_mangle]`.
-fn fn_is_exported(f: &ItemFn) -> bool {
-    f.attrs.iter().any(is_link_attr)
+/// Returns `true` if the attributes include a link attribute such as `#[no_mangle]` that exports
+/// the item to other compilation units.
+fn attrs_are_exported(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(is_link_attr)
 }
 
 fn token_stream_contains_unsafe(tokens: TokenStream) -> bool {
@@ -83,24 +87,52 @@ struct Output {
 }
 
 #[derive(Clone, Debug)]
-enum ItemKind<'a> {
-    Fn(&'a Ident),
-    Static(&'a Ident),
+enum ItemKind {
+    Fn(String),
+    Static(String),
+}
+
+/// Tracks the enclosing `impl` or `trait` so methods can be reported with a qualified name.
+#[derive(Clone, Debug)]
+enum MethodScope {
+    /// `impl Type { ... }` — methods are reported as `Type::method`.
+    Inherent(String),
+    /// `impl Trait for Type { ... }` — methods are reported as `<Type as Trait>::method`.
+    TraitImpl { self_ty: String, trait_path: String },
+    /// `trait Trait { ... }` — default methods are reported as `Trait::method`.
+    TraitDef(String),
+}
+
+impl MethodScope {
+    fn qualify(&self, method: &syn::Ident) -> String {
+        match self {
+            MethodScope::Inherent(ty) => format!("{}::{}", ty, method),
+            MethodScope::TraitImpl { self_ty, trait_path } => {
+                format!("<{} as {}>::{}", self_ty, trait_path, method)
+            }
+            MethodScope::TraitDef(tr) => format!("{}::{}", tr, method),
+        }
+    }
+}
+
+fn type_to_string<T: ToTokens>(ty: &T) -> String {
+    ty.to_token_stream().to_string()
 }
 
 #[derive(Clone, Debug)]
-enum TraversalScope<'a> {
-    Item(ItemKind<'a>),
+enum TraversalScope {
+    Item(ItemKind),
+    Method(MethodScope),
 }
 
 #[derive(Clone, Debug, Default)]
-struct Visitor<'a> {
+struct Visitor {
     out: Output,
-    scopes: Vec<TraversalScope<'a>>,
+    scopes: Vec<TraversalScope>,
 }
 
-impl<'a> Visitor<'a> {
-    fn with_scope(&mut self, scope: TraversalScope<'a>, visit: impl FnOnce(&mut Self)) {
+impl Visitor {
+    fn with_scope(&mut self, scope: TraversalScope, visit: impl FnOnce(&mut Self)) {
         self.scopes.push(scope);
         visit(self);
         self.scopes
@@ -108,19 +140,29 @@ impl<'a> Visitor<'a> {
             .expect("scope pushed immediately before traversal");
     }
 
-    fn current_item(&self) -> Option<&ItemKind<'a>> {
-        self.scopes.iter().rev().find_map(|scope| match scope {
-            TraversalScope::Item(item) => Some(item),
+    fn current_item(&self) -> Option<&ItemKind> {
+        // TODO: Treat `Method` as a boundary when finding the current item. Searching past it
+        // preserves the old two-field behavior, but can attribute unsafe in an untracked
+        // associated item of a local impl to the enclosing function.
+        self.scopes.iter().rev().find_map(|s| match s {
+            TraversalScope::Item(i) => Some(i),
+            TraversalScope::Method(_) => None,
+        })
+    }
+
+    fn method_scope(&self) -> Option<&MethodScope> {
+        self.scopes.iter().rev().find_map(|s| match s {
+            TraversalScope::Item(_) => None,
+            TraversalScope::Method(m) => Some(m),
         })
     }
 }
 
-impl<'ast> Visit<'ast> for Visitor<'ast> {
+impl<'ast> Visit<'ast> for Visitor {
     fn visit_item_fn(&mut self, item_fn: &'ast ItemFn) {
-        let ident = &item_fn.sig.ident;
-        let name = ident.to_string();
+        let name = item_fn.sig.ident.to_string();
         if item_fn.sig.unsafety.is_some() {
-            if fn_is_exported(item_fn) {
+            if attrs_are_exported(&item_fn.attrs) {
                 // Ignore unsafety inside of FFI entry points, as it's often unavoidable.
                 return;
             } else {
@@ -128,27 +170,85 @@ impl<'ast> Visit<'ast> for Visitor<'ast> {
             }
         }
 
-        self.with_scope(TraversalScope::Item(ItemKind::Fn(ident)), |visitor| {
-            visit::visit_item_fn(visitor, item_fn)
+        self.with_scope(TraversalScope::Item(ItemKind::Fn(name)), |v| {
+            visit::visit_item_fn(v, item_fn)
+        });
+    }
+
+    fn visit_item_impl(&mut self, item_impl: &'ast ItemImpl) {
+        let self_ty = type_to_string(&*item_impl.self_ty);
+        let scope = match &item_impl.trait_ {
+            Some((_bang, trait_path, _for)) => MethodScope::TraitImpl {
+                self_ty,
+                trait_path: type_to_string(trait_path),
+            },
+            None => MethodScope::Inherent(self_ty),
+        };
+        self.with_scope(TraversalScope::Method(scope), |v| {
+            visit::visit_item_impl(v, item_impl)
+        });
+    }
+
+    fn visit_item_trait(&mut self, item_trait: &'ast ItemTrait) {
+        self.with_scope(
+            TraversalScope::Method(MethodScope::TraitDef(item_trait.ident.to_string())),
+            |v| visit::visit_item_trait(v, item_trait),
+        );
+    }
+
+    fn visit_impl_item_fn(&mut self, item_fn: &'ast ImplItemFn) {
+        let name = match self.method_scope() {
+            Some(scope) => scope.qualify(&item_fn.sig.ident),
+            None => item_fn.sig.ident.to_string(),
+        };
+        if item_fn.sig.unsafety.is_some() {
+            if attrs_are_exported(&item_fn.attrs) {
+                return;
+            } else {
+                self.out.internal_unsafe_fns.push(name.clone());
+            }
+        }
+
+        self.with_scope(TraversalScope::Item(ItemKind::Fn(name)), |v| {
+            visit::visit_impl_item_fn(v, item_fn)
+        });
+    }
+
+    fn visit_trait_item_fn(&mut self, item_fn: &'ast TraitItemFn) {
+        // Only default-method bodies can contain `unsafe` blocks; signatures without bodies are
+        // still tracked for `unsafe fn` reporting.
+        let name = match self.method_scope() {
+            Some(scope) => scope.qualify(&item_fn.sig.ident),
+            None => item_fn.sig.ident.to_string(),
+        };
+        if item_fn.sig.unsafety.is_some() {
+            if attrs_are_exported(&item_fn.attrs) {
+                return;
+            } else {
+                self.out.internal_unsafe_fns.push(name.clone());
+            }
+        }
+
+        self.with_scope(TraversalScope::Item(ItemKind::Fn(name)), |v| {
+            visit::visit_trait_item_fn(v, item_fn)
         });
     }
 
     fn visit_item_static(&mut self, item_static: &'ast ItemStatic) {
-        let ident = &item_static.ident;
-        let name = ident.to_string();
+        let name = item_static.ident.to_string();
         if matches!(item_static.mutability, StaticMutability::Mut(_)) {
             self.out.mutable_statics.insert(name.clone());
         }
 
-        self.with_scope(TraversalScope::Item(ItemKind::Static(ident)), |visitor| {
-            visit::visit_item_static(visitor, item_static)
+        self.with_scope(TraversalScope::Item(ItemKind::Static(name)), |v| {
+            visit::visit_item_static(v, item_static)
         });
     }
 
     fn visit_expr_unsafe(&mut self, x: &'ast ExprUnsafe) {
         match self.current_item() {
-            Some(ItemKind::Fn(ident)) => self.out.fns_containing_unsafe.insert(ident.to_string()),
-            Some(ItemKind::Static(ident)) => self.out.statics_containing_unsafe.insert(ident.to_string()),
+            Some(ItemKind::Fn(name)) => self.out.fns_containing_unsafe.insert(name.clone()),
+            Some(ItemKind::Static(name)) => self.out.statics_containing_unsafe.insert(name.clone()),
             None => <_>::default(),
         };
         visit::visit_expr_unsafe(self, x);
@@ -186,7 +286,7 @@ impl<'ast> Visit<'ast> for Visitor<'ast> {
         if token_stream_contains_unsafe(mac.tokens.clone()) {
             // Attribute unsafe usage in macro invocation to the function we're in, if we can
             match self.current_item() {
-                Some(ItemKind::Fn(ident)) | Some(ItemKind::Static(ident)) => self.out.fns_containing_unsafe.insert(ident.to_string()),
+                Some(ItemKind::Fn(ident)) | Some(ItemKind::Static(ident)) => self.out.fns_containing_unsafe.insert(ident.clone()),
                 None => self.out.global_macro_invocations_containing_unsafe.insert(name),
             };
         }

--- a/tools/find_unsafe/src/main.rs
+++ b/tools/find_unsafe/src/main.rs
@@ -88,10 +88,31 @@ enum ItemKind<'a> {
     Static(&'a Ident),
 }
 
+#[derive(Clone, Debug)]
+enum TraversalScope<'a> {
+    Item(ItemKind<'a>),
+}
+
 #[derive(Clone, Debug, Default)]
 struct Visitor<'a> {
     out: Output,
-    current_item: Option<ItemKind<'a>>,
+    scopes: Vec<TraversalScope<'a>>,
+}
+
+impl<'a> Visitor<'a> {
+    fn with_scope(&mut self, scope: TraversalScope<'a>, visit: impl FnOnce(&mut Self)) {
+        self.scopes.push(scope);
+        visit(self);
+        self.scopes
+            .pop()
+            .expect("scope pushed immediately before traversal");
+    }
+
+    fn current_item(&self) -> Option<&ItemKind<'a>> {
+        self.scopes.iter().rev().find_map(|scope| match scope {
+            TraversalScope::Item(item) => Some(item),
+        })
+    }
 }
 
 impl<'ast> Visit<'ast> for Visitor<'ast> {
@@ -107,9 +128,9 @@ impl<'ast> Visit<'ast> for Visitor<'ast> {
             }
         }
 
-        let old = self.current_item.replace(ItemKind::Fn(ident));
-        visit::visit_item_fn(self, item_fn);
-        self.current_item = old;
+        self.with_scope(TraversalScope::Item(ItemKind::Fn(ident)), |visitor| {
+            visit::visit_item_fn(visitor, item_fn)
+        });
     }
 
     fn visit_item_static(&mut self, item_static: &'ast ItemStatic) {
@@ -119,13 +140,13 @@ impl<'ast> Visit<'ast> for Visitor<'ast> {
             self.out.mutable_statics.insert(name.clone());
         }
 
-        let old = self.current_item.replace(ItemKind::Static(ident));
-        visit::visit_item_static(self, item_static);
-        self.current_item = old;
+        self.with_scope(TraversalScope::Item(ItemKind::Static(ident)), |visitor| {
+            visit::visit_item_static(visitor, item_static)
+        });
     }
 
     fn visit_expr_unsafe(&mut self, x: &'ast ExprUnsafe) {
-        match self.current_item {
+        match self.current_item() {
             Some(ItemKind::Fn(ident)) => self.out.fns_containing_unsafe.insert(ident.to_string()),
             Some(ItemKind::Static(ident)) => self.out.statics_containing_unsafe.insert(ident.to_string()),
             None => <_>::default(),
@@ -164,7 +185,7 @@ impl<'ast> Visit<'ast> for Visitor<'ast> {
 
         if token_stream_contains_unsafe(mac.tokens.clone()) {
             // Attribute unsafe usage in macro invocation to the function we're in, if we can
-            match &self.current_item {
+            match self.current_item() {
                 Some(ItemKind::Fn(ident)) | Some(ItemKind::Static(ident)) => self.out.fns_containing_unsafe.insert(ident.to_string()),
                 None => self.out.global_macro_invocations_containing_unsafe.insert(name),
             };

--- a/tools/find_unsafe/src/test_funcs.rs
+++ b/tools/find_unsafe/src/test_funcs.rs
@@ -23,3 +23,33 @@ fn g() {
     unsafe { }
     unsafe { unsafe { } }
 }
+
+struct H;
+
+// Inherent impl: mark `H::h` as containing unsafe.
+impl H {
+    fn h(&self) {
+        unsafe { }
+    }
+
+    // Mark `H::i` both as containing unsafe and as an unsafe fn.
+    unsafe fn i(&self) {
+        unsafe { }
+    }
+}
+
+trait J {
+    fn j(&self);
+
+    // Default trait method body: mark `J::k` as containing unsafe.
+    fn k(&self) {
+        unsafe { }
+    }
+}
+
+// Trait impl: mark `<H as J>::j` as containing unsafe.
+impl J for H {
+    fn j(&self) {
+        unsafe { }
+    }
+}


### PR DESCRIPTION
Closes #125

Side effect: unsafe inside impl/trait methods that was previously attributed elsewhere (to the enclosing fn for function-local impls, or to `global_macro_invocations_containing_unsafe` for macros in methods) is now attributed to the method itself.