### PR TITLE
Add on-accept hook to crisp main

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -58,6 +58,8 @@ def parse_args():
 
     main = sub.add_parser('main')
     main.add_argument('node', nargs='?', default='c_code')
+    main.add_argument('--on-accept', metavar='COMMAND',
+        help='Run COMMAND after each accepted CRISP state.')
     main.add_argument('--llm-mode',
         choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
         default='default',
@@ -592,6 +594,8 @@ def main():
     cfg_kwargs = {}
     if args.mvir_storage_dir is not None:
         cfg_kwargs['mvir_storage_dir'] = os.path.abspath(args.mvir_storage_dir)
+    if getattr(args, 'on_accept', None) is not None:
+        cfg_kwargs['on_accept'] = args.on_accept
     cfg = Config.from_toml_file(args.config_path, **cfg_kwargs)
 
     if args.cmd == 'main':

--- a/crisp/config.py
+++ b/crisp/config.py
@@ -57,6 +57,7 @@ class Config(ConfigBase):
     test_command: str | None = None
     base_dir: str = '.'
     mvir_storage_dir: str = 'crisp-storage'
+    on_accept: str | None = None
     # `model = None` means call `/v1/models` and pick the first from the list.
     model: str | None = None
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -231,6 +231,19 @@ class Workflow:
     def accept(self, code: TreeNode, reason = None):
         self.mvir.set_tag('current', code.node_id(), reason)
 
+        if self.cfg.on_accept is not None:
+            try:
+                p = subprocess.run([self.cfg.on_accept], check=False)
+            except OSError as e:
+                print(f'warning: on-accept hook failed to run: {e}', file=sys.stderr)
+            else:
+                if p.returncode != 0:
+                    print(
+                        f'warning: on-accept hook exited with status {p.returncode}',
+                        file=sys.stderr,
+                    )
+                    print(f'warning: on-accept hook cwd: {os.getcwd()}', file=sys.stderr)
+
     @step
     def cc_cmake(self, c_code: TreeNode) -> FileNode:
         n_op_cc = self.cc_cmake_op(c_code)


### PR DESCRIPTION
Adds an additional argument `--on-accept` to the `crisp main` command that allows users to specify a command to run every time `Workflow.accept` is called. This is intended to allow us to do periodic s3 uploads as the CRISP loop makes progress, rather than waiting until the process finishes to do the upload.