### PR TITLE
Update `codex` configuration to disable fast mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN cargo-docker-clean.sh /opt/crisp-tools/install-all.sh
 # Install codex-cli
 RUN mkdir /opt/codex-cli \
     && cd /opt/codex-cli \
-    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.132.0/codex-x86_64-unknown-linux-musl.tar.gz \
+    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.135.0/codex-x86_64-unknown-linux-musl.tar.gz \
     && wget --quiet "$codex_url" \
     && tar -xzf "$(basename "$codex_url")" \
     && ln -s "$PWD/codex-x86_64-unknown-linux-musl" /usr/local/bin/codex \

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -50,9 +50,17 @@ def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> l
             cmd += ['-c', f'{k}={v}']
         cmd += ['--profile', 'crisp']
 
-    cmd += ['-c', 'model_reasoning_effort="high"',
-            # Fast mode uses 1.5-2x more tokens, so use the standard tier
-            '-c', 'service_tier="standard"']
+    # Fast (aka. priority) mode delivers 1.5 faster tokens at 2.5x credit use [0].
+    # The service tier selection mechanism can be entirely disabled by setting 
+    # `fast_mode == false` [1].
+    #
+    # [0]: https://developers.openai.com/codex/speed
+    # [1]: https://github.com/openai/codex/blob/main/codex-rs/tui/src/service_tier_resolution.rs#L18
+    cmd += [
+        '-c', 'model_reasoning_effort="high"',
+        '-c', 'features.fast_mode=false',
+    ]
+    
     cmd += args
     return cmd
 


### PR DESCRIPTION
Fast mode delivers 1.5x faster tokens for 2.5x higher credit usage on gpt-5.5 which can lead to billing surprises and exhaust 5h windows.

Also updates Dockerfile to latest codex (v0.135).