### PR TITLE
Enable postprocess in Crisp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,12 @@ RUN cd /opt/c2rust \
     && cargo-docker-clean.sh cargo install --locked --path /opt/c2rust/c2rust
 RUN cd /opt/c2rust \
     && cargo-docker-clean.sh cargo install --locked --path c2rust-refactor
+# `c2rust` discovers subcommands by looking for `c2rust-*` binaries adjacent
+# to its own executable, but `uv sync` installs `postprocess` elsewhere.
+# Expose the installed entry point at the name and location `c2rust` expects.
+RUN cd /opt/c2rust/c2rust-postprocess \
+    && uv sync \
+    && ln -s /opt/c2rust/c2rust-postprocess/.venv/bin/postprocess /usr/local/cargo/bin/c2rust-postprocess
 
 # Install hayroll
 #

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -253,6 +253,29 @@ def do_main(args, cfg):
         return
     w.accept(n_code, ('main', 'transpile'))
 
+    # Postprocess can fail by the tool itself failing, the output being not
+    # buildable, or the output failing the tests.  In all cases, failure is not
+    # fatal.
+    if w.codex_login:
+        # c2rust-postprocess does not support codex credentials yet.
+        print('skipping postprocess: not supported with --codex-login')
+    else:
+        try:
+            n_postprocess_code = w.postprocess(n_code)
+        except CrispError as e:
+            print(f'error: postprocess failed: {type(e).__name__}: {e}')
+        else:
+            if not w.cargo_check_json_op(n_postprocess_code).passed:
+                print('error: build failed after postprocess')
+            elif not w.test(n_postprocess_code, n_c_code):
+                print('error: tests failed after postprocess')
+            else:
+                n_code = n_postprocess_code
+                w.accept(n_code, ('main', 'postprocess'))
+
+    n_code = w.drop_c_decls_artifacts(n_code)
+    w.accept(n_code, ('main', 'drop_c_decls_artifacts'))
+
     n_code = w.split_ffi(n_code)
     if not w.cargo_check_json_op(n_code).passed:
         print('error: build failed after split_ffi')

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -817,6 +817,20 @@ class CargoFixOpNode(Node):
     cmd = property(lambda self: self._metadata['cmd'])
     exit_code = property(lambda self: self._metadata['exit_code'])
 
+class PostprocessOpNode(Node):
+    KIND = 'postprocess_op'
+    old_code: Metadata[NodeId]
+    # `new_code` is an empty `TreeNode` when the postprocess run failed.
+    new_code: Metadata[NodeId]
+    cmd: Metadata[list[str]]
+    exit_code: Metadata[int]
+    # `body` stores the log output
+
+    old_code = property(lambda self: self._metadata['old_code'])
+    new_code = property(lambda self: self._metadata['new_code'])
+    cmd = property(lambda self: self._metadata['cmd'])
+    exit_code = property(lambda self: self._metadata['exit_code'])
+
 
 class DefNode(Node):
     KIND = 'def'
@@ -938,6 +952,7 @@ NODE_CLASSES = [
     CheckUnsafe2AnalysisNode,
     EditOpNode,
     CargoFixOpNode,
+    PostprocessOpNode,
 
     DefNode,
     CrateNode,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -596,21 +596,29 @@ class Workflow:
         with run_sandbox(cfg, mvir) as sb:
             sb.checkout(n_tree)
 
-            postprocess_cmd = [
-                'c2rust',
-                'postprocess',
-                '--update-rust',
-                '--on-error',
-                'warn',
-                '--no-update-cache',
-            ]
-            postprocess_cmd.append(sb.join(root_rust_source_file))
+            postprocess_model = (
+                os.environ.get('CRISP_API_MODEL') or cfg.models.postprocess
+            )
 
             postprocess_env = {
                 key: value
-                for key in ('CRISP_API_BASE', 'CRISP_API_KEY', 'CRISP_API_MODEL')
+                for key in ('CRISP_API_BASE', 'CRISP_API_KEY')
                 if (value := os.environ.get(key)) is not None
             }
+
+            # c2rust-postprocess uses CRISP credentials only when CRISP_API_MODEL is set.
+            if 'CRISP_API_KEY' in postprocess_env:
+                postprocess_env['CRISP_API_MODEL'] = postprocess_model
+
+            postprocess_cmd = [
+                'c2rust', 'postprocess',
+                '--update-rust',
+                '--on-error', 'warn',
+                '--no-update-cache',
+                '--llm-model', postprocess_model,
+                sb.join(root_rust_source_file),
+            ]
+
             exit_code, logs = sb.run(
                 postprocess_cmd, stream=True, env=postprocess_env)
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -21,7 +21,7 @@ from .mvir import (
     CargoCheckJsonAnalysisNode, EditOpNode, WorkflowStepInputsNode,
     WorkflowStepNode, SplitOpNode, MergeOpNode, CrateNode, DefNode,
     RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
-    CargoFixOpNode,
+    CargoFixOpNode, PostprocessOpNode,
 )
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir
@@ -492,6 +492,7 @@ class Workflow:
                     "--output-dir",
                     sb.join(output_path),
                     "--emit-build-files",
+                    "--emit-c-decl-map",
                 ]
                 if src_loc_annotations:
                     c2rust_cmd += [
@@ -577,6 +578,97 @@ class Workflow:
         print('c2rust process %s with code %d:\n%s' % (
             'succeeded' if n_op.exit_code == 0 else 'failed', n_op.exit_code, n_op.cmd))
 
+        return n_op
+
+    @step
+    def postprocess(self, n_tree: TreeNode) -> TreeNode:
+        n_op = self.postprocess_op(n_tree)
+        return self.mvir.node(n_op.new_code)
+
+    @step
+    def postprocess_op(self, n_tree: TreeNode) -> PostprocessOpNode:
+        cfg, mvir = self.cfg, self.mvir
+
+        rust_path_rel = cfg.relative_path(cfg.transpile.output_dir)
+        root_file_rel = analysis.detect_root_file(cfg, mvir, n_tree)
+        root_rust_source_file = os.path.join(rust_path_rel, root_file_rel)
+
+        with run_sandbox(cfg, mvir) as sb:
+            sb.checkout(n_tree)
+
+            postprocess_cmd = [
+                'c2rust',
+                'postprocess',
+                '--update-rust',
+                '--on-error',
+                'warn',
+                '--no-update-cache',
+            ]
+            postprocess_cmd.append(sb.join(root_rust_source_file))
+
+            postprocess_env = {
+                key: value
+                for key in ('CRISP_API_BASE', 'CRISP_API_KEY', 'CRISP_API_MODEL')
+                if (value := os.environ.get(key)) is not None
+            }
+            exit_code, logs = sb.run(
+                postprocess_cmd, stream=True, env=postprocess_env)
+
+            if exit_code == 0:
+                n_new_tree = sb.commit_dir(rust_path_rel)
+                if n_new_tree.node_id() == n_tree.node_id():
+                    print(
+                        'warning: c2rust-postprocess completed successfully, '
+                        'but the committed tree is unchanged'
+                    )
+            else:
+                # Placeholder so the failed run is still recorded in the MVIR.
+                n_new_tree = TreeNode.new(mvir, files={})
+
+        n_op = PostprocessOpNode.new(
+            mvir,
+            old_code=n_tree.node_id(),
+            new_code=n_new_tree.node_id(),
+            cmd=postprocess_cmd,
+            exit_code=exit_code,
+            body=logs.decode('utf-8', errors='replace'),
+        )
+        mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
+
+        if exit_code != 0:
+            raise CrispError('c2rust-postprocess failed', n_op)
+
+        return n_op
+
+    @step
+    def drop_c_decls_artifacts(self, code: TreeNode) -> TreeNode:
+        n_op = self.drop_c_decls_artifacts_op(code)
+        if n_op.new_code == code.node_id():
+            return code
+        return self.mvir.node(n_op.new_code)
+
+    @step
+    def drop_c_decls_artifacts_op(self, code: TreeNode) -> EditOpNode:
+        mvir = self.mvir
+
+        new_files = {
+            path: node_id
+            for path, node_id in code.files.items()
+            if not path.endswith('.c_decls.json')
+        }
+        new_code = TreeNode.new(mvir, files=new_files)
+
+        n_op = EditOpNode.new(
+            mvir,
+            old_code=code.node_id(),
+            new_code=new_code.node_id(),
+            body='drop c2rust c-decl artifacts',
+        )
+        mvir.set_tag(
+            'op_history',
+            n_op.node_id(),
+            n_op.kind + ' drop_c_decls_artifacts',
+        )
         return n_op
 
     @step


### PR DESCRIPTION
Runs `c2rust-postprocess` after transpilation as a best-effort cleanup step.

- Installs the postprocessor and records each invocation and result in MVIR.
- Selects the model from `models.postprocess`, with `CRISP_API_MODEL` as an override.
- Accepts output only when it builds and passes tests; otherwise CRISP falls back to the original transpilation.
- Removes C declaration-map artifacts afterward.

Postprocessing is untested with hayroll transpilation. Codex support in the postprocessor is deferred, so the postprocess step is skipped when CRISP runs with `--codex-login`.