### PR TITLE
find_unsafe2: add stricter raw pointer checks; misc fixes

### DIFF
--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -60,3 +60,11 @@ static FFI2: i32 = {
 unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
     unsafe { *p }
 }
+
+
+fn test_write() {
+    use std::io::Write;
+    // `writeln!` uses unsafe `std::fmt` internals, but shouldn't be counted as unsafe.
+    let mut stdout = std::io::stdout().lock();
+    let _ = writeln!(stdout, "x = {}", 1 + 1);
+}

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -39,7 +39,13 @@ fn f6(r: &i32) -> i32 {
     *r
 }
 
-unsafe fn f7(x: usize) -> i32 {
+unsafe fn f7a(x: usize) -> i32 {
+    // Error: integer-to-pointer casts are forbidden.
+    *(x as *const i32)
+}
+
+unsafe fn f7b(x: &i32) -> i32 {
+    // No error; reference-to-pointer casts are allowed.
     *(x as *const i32)
 }
 

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -66,6 +66,12 @@ unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
 }
 
 
+struct S {
+    // Error: added a raw pointer to this field type.
+    x: *const i32,
+}
+
+
 fn test_write() {
     use std::io::Write;
     // `writeln!` uses unsafe `std::fmt` internals, but shouldn't be counted as unsafe.

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -38,6 +38,10 @@ fn f6(r: &i32) -> i32 {
     *r
 }
 
+unsafe fn f7(x: usize) -> i32 {
+    *(x as *const i32)
+}
+
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn ffi1(p: *const i32) -> i32 {

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+use std::ptr::NonNull;
 
 fn f1(x: i32) {
     // `println` internally use `fmt::Arguments::new`, which is an unsafe function.
@@ -69,6 +70,8 @@ unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
 struct S {
     // Error: added a raw pointer to this field type.
     x: *const i32,
+    // Error - NonNull also counts as a raw pointer type.
+    y: NonNull<i32>,
 }
 
 

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -43,6 +43,10 @@ fn f6(r: &i32) -> i32 {
     unsafe { f3(r) }
 }
 
+unsafe fn f7(x: *const i32) -> i32 {
+    *x
+}
+
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn ffi1(p: *const i32) -> i32 {

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -63,4 +63,5 @@ unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
 
 struct S {
     x: i32,
+    y: i32,
 }

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -59,3 +59,8 @@ static FFI2: i32 = 0;
 unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
     unsafe { *p }
 }
+
+
+struct S {
+    x: i32,
+}

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -43,7 +43,11 @@ fn f6(r: &i32) -> i32 {
     unsafe { f3(r) }
 }
 
-unsafe fn f7(x: *const i32) -> i32 {
+unsafe fn f7a(x: *const i32) -> i32 {
+    *x
+}
+
+unsafe fn f7b(x: *const i32) -> i32 {
     *x
 }
 

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -14,14 +14,14 @@ use std::process;
 use indexmap::IndexMap;
 use rustc_public::error::CompilerError;
 use serde_json;
-use find_unsafe2::{self, Outputs, FunctionOutputs};
+use find_unsafe2::{self, Outputs, FunctionOutputs, TypeOutputs};
 
 
 /// Check whether the unsafe operations recorded in `new` are a subset of those recorded in `old`.
 /// Prints an error for each thing in `new` that doesn't appear in `old`, and returns `false` if it
 /// found any such things.
 fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
-    let Outputs { total_unsafe: _, ref fns } = *new;
+    let Outputs { total_unsafe: _, ref fns, ref types } = *new;
     let mut ok = true;
 
     // We use this default `FunctionOutputs` as the `old_fn` for items that are defined in `new`
@@ -36,11 +36,20 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
         uses_union_field: Default::default(),
         uses_foreign_fn: Default::default(),
         casts_int_to_ptr: 0,
+        sig_contains_raw_ptr: 0,
         is_ffi_entry_point: false,
     };
     for (fn_name, new_fn) in fns {
         let old_fn = old.fns.get(fn_name).unwrap_or(&empty_fn);
         ok &= check_function_outputs(fn_name, old_fn, new_fn);
+    }
+
+    let empty_type = TypeOutputs {
+        contains_raw_ptr: 0,
+    };
+    for (type_name, new_type) in types {
+        let old_type = old.types.get(type_name).unwrap_or(&empty_type);
+        ok &= check_type_outputs(type_name, old_type, new_type);
     }
 
     ok
@@ -55,7 +64,7 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
     let FunctionOutputs {
         is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
-        casts_int_to_ptr,
+        casts_int_to_ptr, sig_contains_raw_ptr,
         is_ffi_entry_point,
     } = *new;
     let mut ok = true;
@@ -79,9 +88,23 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
 
     ok &= check_count(old.casts_int_to_ptr, casts_int_to_ptr,
         || format!("{name}: int-to-pointer casts"));
+    ok &= check_count(old.sig_contains_raw_ptr, sig_contains_raw_ptr,
+        || format!("{name}: raw pointer types in signature"));
 
     ok &= check_bad_flag(old.is_ffi_entry_point, is_ffi_entry_point,
         || format!("{name}: FFI export flag"));
+
+    ok
+}
+
+fn check_type_outputs(name: &str, old: &TypeOutputs, new: &TypeOutputs) -> bool {
+    let TypeOutputs {
+        contains_raw_ptr,
+    } = *new;
+    let mut ok = true;
+
+    ok &= check_count(old.contains_raw_ptr, contains_raw_ptr,
+        || format!("{name}: raw pointer types"));
 
     ok
 }

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -32,9 +32,9 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
         is_mut_static: false,
         derefs_raw_ptr: 0,
         calls_unsafe: 0,
-        uses_static_mut: Default::default(),
-        uses_union_field: Default::default(),
-        uses_foreign_fn: Default::default(),
+        uses_static_mut: IndexMap::new(),
+        uses_union_field: IndexMap::new(),
+        uses_foreign_fn: IndexMap::new(),
         casts_int_to_ptr: 0,
         sig_contains_raw_ptr: 0,
         is_ffi_entry_point: false,
@@ -45,7 +45,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
     }
 
     let empty_type = TypeOutputs {
-        contains_raw_ptr: 0,
+        field_contains_raw_ptr: IndexMap::new(),
     };
     for (type_name, new_type) in types {
         let old_type = old.types.get(type_name).unwrap_or(&empty_type);
@@ -99,12 +99,12 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
 
 fn check_type_outputs(name: &str, old: &TypeOutputs, new: &TypeOutputs) -> bool {
     let TypeOutputs {
-        contains_raw_ptr,
+        ref field_contains_raw_ptr,
     } = *new;
     let mut ok = true;
 
-    ok &= check_count(old.contains_raw_ptr, contains_raw_ptr,
-        || format!("{name}: raw pointer types"));
+    ok &= check_count_map(&old.field_contains_raw_ptr, field_contains_raw_ptr,
+        |k| format!("{name}: field {k} raw pointer count"));
 
     ok
 }

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -28,6 +28,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
     // but not in `old`.  All unsafety and progress metrics are set to zero, so if the agent adds a
     // new unsafe function that wasn't present before, we detect that as a regression.
     let empty_fn = FunctionOutputs {
+        total_unsafe: 0,
         is_unsafe_fn: false,
         is_mut_static: false,
         derefs_raw_ptr: 0,
@@ -62,6 +63,8 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
     }
 
     let FunctionOutputs {
+        // Don't check the total.  Each element that feeds into this total is checked individually.
+        total_unsafe: _,
         is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
         casts_int_to_ptr, sig_contains_raw_ptr,

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -35,6 +35,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
         uses_static_mut: Default::default(),
         uses_union_field: Default::default(),
         uses_foreign_fn: Default::default(),
+        casts_int_to_ptr: 0,
         is_ffi_entry_point: false,
     };
     for (fn_name, new_fn) in fns {
@@ -54,6 +55,7 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
     let FunctionOutputs {
         is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
+        casts_int_to_ptr,
         is_ffi_entry_point,
     } = *new;
     let mut ok = true;
@@ -74,6 +76,9 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
         |k| format!("{name}: uses of union field {k}"));
     ok &= check_count_map(&old.uses_foreign_fn, uses_foreign_fn,
         |k| format!("{name}: uses of foreign fn {k}"));
+
+    ok &= check_count(old.casts_int_to_ptr, casts_int_to_ptr,
+        || format!("{name}: int-to-pointer casts"));
 
     ok &= check_bad_flag(old.is_ffi_entry_point, is_ffi_entry_point,
         || format!("{name}: FFI export flag"));

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -226,8 +226,11 @@ pub struct FunctionOutputs {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TypeOutputs {
-    /// Progress: the type or its fields contain raw pointers.
-    pub contains_raw_ptr: usize,
+    /// Progress: a field of this type contains a raw pointer.
+    ///
+    /// For type alias like `type Foo = *const u8;`, we treat the RHS as a field named "type", so
+    /// in this case `Foo` would have `field_contains_raw_ptr["field"] == 1`.
+    pub field_contains_raw_ptr: IndexMap<String, usize>,
 }
 
 
@@ -255,7 +258,7 @@ impl TypeOutputs {
     fn total_unsafe(&self) -> usize {
         let TypeOutputs {
             // Progress, not safety
-            contains_raw_ptr: _,
+            field_contains_raw_ptr: _,
         } = *self;
 
         0
@@ -330,18 +333,23 @@ fn sig_contains_raw_ptr(item: CrateItem) -> usize {
     }
 }
 
-fn type_def_contains_raw_ptr(td: &TypeDef) -> usize {
+fn type_def_field_contains_raw_ptr(td: &TypeDef) -> IndexMap<String, usize> {
     match *td {
         TypeDef::Adt(adt) => {
-            let mut count = 0;
+            let mut counts = IndexMap::new();
             for v in adt.variants_iter() {
                 for f in v.fields() {
-                    count += ty_contains_raw_ptr(f.ty());
+                    // Use `entry` instead of `insert` in case there are multiple enum variants
+                    // with the same field name (we don't distinguish between variants currently).
+                    *counts.entry(f.name.to_string()).or_insert(0) += ty_contains_raw_ptr(f.ty());
                 }
             }
-            count
+            counts
         },
-        TypeDef::Alias(_, ref ty) => ty_contains_raw_ptr(ty.value),
+        // For type aliases, record the count under the dummy field name "type".
+        TypeDef::Alias(_, ref ty) => [
+            (String::from("type"), ty_contains_raw_ptr(ty.value)),
+        ].into(),
     }
 }
 
@@ -457,7 +465,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
     for td in crate_type_defs(tcx) {
         let key: String = td.name();
         let value = TypeOutputs {
-            contains_raw_ptr: type_def_contains_raw_ptr(&td),
+            field_contains_raw_ptr: type_def_field_contains_raw_ptr(&td),
         };
         out.total_unsafe += value.total_unsafe();
         let old = out.types.insert(key, value);

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -177,6 +177,9 @@ pub struct Outputs {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionOutputs {
+    /// Sum of all unsafe counts for this function.
+    pub total_unsafe: usize,
+
     /// Unsafety: the function itself is unsafe.
     ///
     /// It's actually safe to define an `unsafe fn`, but we count this in our unsafety metrics so
@@ -235,8 +238,9 @@ pub struct TypeOutputs {
 
 
 impl FunctionOutputs {
-    fn total_unsafe(&self) -> usize {
+    fn calc_total_unsafe(&mut self) {
         let FunctionOutputs {
+            ref mut total_unsafe,
             is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
             ref uses_static_mut, ref uses_union_field,
             // Progress, not safety
@@ -245,12 +249,12 @@ impl FunctionOutputs {
             is_ffi_entry_point: _,
         } = *self;
 
-        is_unsafe_fn as usize
+        *total_unsafe = is_unsafe_fn as usize
             + is_mut_static as usize
             + derefs_raw_ptr
             + calls_unsafe
             + uses_static_mut.values().copied().sum::<usize>()
-            + uses_union_field.values().copied().sum::<usize>()
+            + uses_union_field.values().copied().sum::<usize>();
     }
 }
 
@@ -442,7 +446,8 @@ pub fn process(tcx: TyCtxt) -> Outputs {
             v.visit_body(&body);
 
             let key: String = item.name();
-            let value = FunctionOutputs {
+            let mut value = FunctionOutputs {
+                total_unsafe: 0,    // Calculated later
                 is_unsafe_fn: is_unsafe_fn(item),
                 is_mut_static: is_mut_static(item),
                 derefs_raw_ptr: v.derefs_raw_ptr,
@@ -462,8 +467,9 @@ pub fn process(tcx: TyCtxt) -> Outputs {
 
                 is_ffi_entry_point: is_ffi_entry_point(item),
             };
+            value.calc_total_unsafe();
             if !value.is_ffi_entry_point {
-                out.total_unsafe += value.total_unsafe();
+                out.total_unsafe += value.total_unsafe;
             }
             let old = out.fns.insert(key, value);
             assert!(old.is_none(), "duplicate fns entry for {:?}", item.name());

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -46,6 +46,8 @@ struct FunctionVisitor<'a> {
     calls_unsafe: usize,
     /// Number of raw pointer dereferences within the current function.
     derefs_raw_ptr: usize,
+    /// Number of int-to-pointer casts within the current function.
+    casts_int_to_ptr: usize,
 }
 
 impl<'a> FunctionVisitor<'a> {
@@ -57,6 +59,7 @@ impl<'a> FunctionVisitor<'a> {
             uses_fields: IndexMap::new(),
             calls_unsafe: 0,
             derefs_raw_ptr: 0,
+            casts_int_to_ptr: 0,
         }
     }
 }
@@ -120,6 +123,13 @@ impl Visitor<'_> for FunctionVisitor<'_> {
                         let idx = union_field_idx.unwrap();
                         *self.uses_fields.entry((adt, idx)).or_insert(0) += 1;
                     },
+                }
+            }
+        } else if let Rvalue::Cast(_kind, ref op, dest_ty) = *x {
+            if dest_ty.kind().is_raw_ptr() {
+                let src_ty = op.ty(self.body.locals()).unwrap();
+                if src_ty.kind().is_integral() {
+                    self.casts_int_to_ptr += 1;
                 }
             }
         }
@@ -194,6 +204,13 @@ pub struct FunctionOutputs {
 
     /// Progress: function mentions imported `extern` `fn`s.
     pub uses_foreign_fn: IndexMap<String, usize>,
+    /// Progress: function casts `usize` to a raw pointer.
+    ///
+    /// This was added after seeing the agent bypass restrictions on raw pointers in data
+    /// structures by replacing the pointer with a `usize` and casting back to a pointer at each
+    /// use site.  We don't ban reference-to-pointer casts since these may come up naturally when a
+    /// function is made mostly safe but it still calls into an unsafe helper.
+    pub casts_int_to_ptr: usize,
     // TODO: Progress: function signature type contains raw pointers.
 
     /// Whether this function is an FFI entry point.  Specifically, this is set when the function
@@ -207,7 +224,7 @@ impl FunctionOutputs {
             is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
             ref uses_static_mut, ref uses_union_field,
             // Progress, not safety
-            uses_foreign_fn: _,
+            uses_foreign_fn: _, casts_int_to_ptr: _,
             // Other
             is_ffi_entry_point: _,
         } = *self;
@@ -315,6 +332,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
                 uses_foreign_fn: v.uses_fns.iter().filter_map(|(&fd, &count)| {
                     is_fn_foreign(fd).then(|| (fd.name(), count))
                 }).collect(),
+                casts_int_to_ptr: v.casts_int_to_ptr,
 
                 is_ffi_entry_point: is_ffi_entry_point(item),
             };

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+extern crate rustc_hir;
 extern crate rustc_middle;
 extern crate rustc_public;
 
@@ -7,6 +8,7 @@ extern crate rustc_public;
 extern crate rustc_driver;
 
 use std::collections::HashMap;
+use std::ops::ControlFlow;
 use indexmap::IndexMap;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::ty::TyCtxt;
@@ -18,7 +20,9 @@ use rustc_public::mir::{
 use rustc_public::mir::alloc::GlobalAlloc;
 use rustc_public::mir::mono::StaticDef;
 use rustc_public::rustc_internal;
-use rustc_public::ty::{RigidTy, ConstantKind, Prov, FnDef, AdtDef, AdtKind};
+use rustc_public::ty::{
+    Ty, RigidTy, ConstantKind, Prov, FnDef, AdtDef, AdtKind, AliasDef, EarlyBinder,
+};
 use serde::{Serialize, Deserialize};
 use crate::mir_visitor::Visitor;
 
@@ -165,11 +169,10 @@ pub struct Outputs {
     pub total_unsafe: usize,
 
     pub fns: IndexMap<String, FunctionOutputs>,
+    pub types: IndexMap<String, TypeOutputs>,
 
     // TODO: Unsafety: crate implements `unsafe trait`s.
     // TODO: Unsafety: crate contains `unsafe extern` imports.
-
-    // TODO: Progress: struct field type contains raw pointers.
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -211,6 +214,9 @@ pub struct FunctionOutputs {
     /// use site.  We don't ban reference-to-pointer casts since these may come up naturally when a
     /// function is made mostly safe but it still calls into an unsafe helper.
     pub casts_int_to_ptr: usize,
+    /// Progress: function signature contains raw pointers.  This includes every occurrence of
+    /// `RigidTy::RawPtr` that appears in the signature, but does not look through type aliases.
+    pub sig_contains_raw_ptr: usize,
     // TODO: Progress: function signature type contains raw pointers.
 
     /// Whether this function is an FFI entry point.  Specifically, this is set when the function
@@ -218,13 +224,20 @@ pub struct FunctionOutputs {
     pub is_ffi_entry_point: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TypeOutputs {
+    /// Progress: the type or its fields contain raw pointers.
+    pub contains_raw_ptr: usize,
+}
+
+
 impl FunctionOutputs {
     fn total_unsafe(&self) -> usize {
         let FunctionOutputs {
             is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
             ref uses_static_mut, ref uses_union_field,
             // Progress, not safety
-            uses_foreign_fn: _, casts_int_to_ptr: _,
+            uses_foreign_fn: _, casts_int_to_ptr: _, sig_contains_raw_ptr: _,
             // Other
             is_ffi_entry_point: _,
         } = *self;
@@ -235,6 +248,100 @@ impl FunctionOutputs {
             + calls_unsafe
             + uses_static_mut.values().copied().sum::<usize>()
             + uses_union_field.values().copied().sum::<usize>()
+    }
+}
+
+impl TypeOutputs {
+    fn total_unsafe(&self) -> usize {
+        let TypeOutputs {
+            // Progress, not safety
+            contains_raw_ptr: _,
+        } = *self;
+
+        0
+    }
+}
+
+
+enum TypeDef {
+    Adt(AdtDef),
+    Alias(AliasDef, EarlyBinder<Ty>),
+}
+
+impl CrateDef for TypeDef {
+    fn def_id(&self) -> DefId {
+        match *self {
+            TypeDef::Adt(adt) => adt.def_id(),
+            TypeDef::Alias(ad, _) => ad.def_id(),
+        }
+    }
+}
+
+fn crate_type_defs(tcx: TyCtxt) -> Vec<TypeDef> {
+    use rustc_hir::def::DefKind;
+    let mut out = Vec::new();
+    for item_id in tcx.hir_free_items() {
+        let did = item_id.owner_id.to_def_id();
+        match tcx.def_kind(did) {
+            DefKind::Struct |
+            DefKind::Union |
+            DefKind::Enum => {
+                out.push(TypeDef::Adt(AdtDef(rustc_internal::stable(did))));
+            },
+            DefKind::TyAlias => {
+                let ty = rustc_internal::stable(tcx.type_of(did));
+                out.push(TypeDef::Alias(AliasDef(rustc_internal::stable(did)), ty));
+            },
+            _ => {},
+        }
+    }
+    out
+}
+
+
+fn ty_contains_raw_ptr(ty: Ty) -> usize {
+    use rustc_public::visitor::{Visitor, Visitable};
+    struct CountRawPtrsVisitor {
+        count: usize,
+    }
+    impl Visitor for CountRawPtrsVisitor {
+        type Break = ();
+        fn visit_ty(&mut self, ty: &Ty) -> ControlFlow<()> {
+            if let Some(&RigidTy::RawPtr(..)) = ty.kind().rigid() {
+                self.count += 1;
+            }
+            ty.super_visit(self)
+        }
+    }
+
+    let mut v = CountRawPtrsVisitor { count: 0 };
+    let _ = ty.visit(&mut v);
+    v.count
+}
+
+fn sig_contains_raw_ptr(item: CrateItem) -> usize {
+    match item.kind() {
+        ItemKind::Fn => {
+            let sig = item.ty().kind().fn_sig().unwrap();
+            sig.value.inputs_and_output.iter().copied().map(ty_contains_raw_ptr).sum()
+        },
+        ItemKind::Static | ItemKind::Const => ty_contains_raw_ptr(item.ty()),
+        ItemKind::Ctor(..) => 0,
+    }
+}
+
+fn type_def_contains_raw_ptr(td: &TypeDef) -> usize {
+    match *td {
+        TypeDef::Adt(adt) => {
+            let mut count = 0;
+            for v in adt.variants_iter() {
+                for f in v.fields() {
+                    count += ty_contains_raw_ptr(f.ty());
+                }
+            }
+            count
+        },
+        TypeDef::Alias(_, ref ty) => ty_contains_raw_ptr(ty.value),
     }
 }
 
@@ -310,7 +417,9 @@ pub fn process(tcx: TyCtxt) -> Outputs {
     let mut out = Outputs {
         total_unsafe: 0,
         fns: IndexMap::new(),
+        types: IndexMap::new(),
     };
+
     for item in items {
         if let Some(body) = item.body() {
             let mut v = FunctionVisitor::new(&body);
@@ -333,6 +442,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
                     is_fn_foreign(fd).then(|| (fd.name(), count))
                 }).collect(),
                 casts_int_to_ptr: v.casts_int_to_ptr,
+                sig_contains_raw_ptr: sig_contains_raw_ptr(item),
 
                 is_ffi_entry_point: is_ffi_entry_point(item),
             };
@@ -340,8 +450,18 @@ pub fn process(tcx: TyCtxt) -> Outputs {
                 out.total_unsafe += value.total_unsafe();
             }
             let old = out.fns.insert(key, value);
-            assert!(old.is_none(), "duplicate entry for {:?}", item.name());
+            assert!(old.is_none(), "duplicate fns entry for {:?}", item.name());
         }
+    }
+
+    for td in crate_type_defs(tcx) {
+        let key: String = td.name();
+        let value = TypeOutputs {
+            contains_raw_ptr: type_def_contains_raw_ptr(&td),
+        };
+        out.total_unsafe += value.total_unsafe();
+        let old = out.types.insert(key, value);
+        assert!(old.is_none(), "duplicate types entry for {:?}", td.name());
     }
 
     out

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -132,7 +132,9 @@ impl Visitor<'_> for FunctionVisitor<'_> {
             let ty = func.ty(self.body.locals()).unwrap();
             if let Some(sig) = ty.kind().fn_sig() {
                 if sig.value.safety == Safety::Unsafe {
-                    let is_allowed_unsafe = x.span.get_filename().ends_with("/std/src/macros.rs");
+                    let filename = x.span.get_filename();
+                    let is_allowed_unsafe = filename.ends_with("/std/src/macros.rs")
+                        || filename.ends_with("/core/src/macros/mod.rs");
                     if !is_allowed_unsafe {
                         self.calls_unsafe += 1;
                     }

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -310,8 +310,16 @@ fn ty_contains_raw_ptr(ty: Ty) -> usize {
     impl Visitor for CountRawPtrsVisitor {
         type Break = ();
         fn visit_ty(&mut self, ty: &Ty) -> ControlFlow<()> {
-            if let Some(&RigidTy::RawPtr(..)) = ty.kind().rigid() {
-                self.count += 1;
+            match ty.kind().rigid() {
+                Some(&RigidTy::RawPtr(..)) => {
+                    self.count += 1;
+                },
+                Some(&RigidTy::Adt(adt, _)) => {
+                    if matches!(&*adt.name(), "core::ptr::NonNull" | "std::ptr::NonNull") {
+                        self.count += 1;
+                    }
+                },
+                _ => {},
             }
             ty.super_visit(self)
         }

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -5,5 +5,6 @@ expression: stdout
 lib::fake_safe_puts: unsafe function calls increased: 0 -> 1
 lib::fake_safe_puts: uses of foreign fn lib::puts increased: 0 -> 1
 lib::deref_ptr: raw pointer derefs increased: 0 -> 1
+lib::f7: int-to-pointer casts increased: 0 -> 1
 lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -10,3 +10,4 @@ lib::deref_ptr: raw pointer types in signature increased: 0 -> 1
 lib::f7: int-to-pointer casts increased: 0 -> 1
 lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true
+lib::S: field x raw pointer count increased: 0 -> 1

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -11,3 +11,4 @@ lib::f7: int-to-pointer casts increased: 0 -> 1
 lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true
 lib::S: field x raw pointer count increased: 0 -> 1
+lib::S: field y raw pointer count increased: 0 -> 1

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -4,7 +4,9 @@ expression: stdout
 ---
 lib::fake_safe_puts: unsafe function calls increased: 0 -> 1
 lib::fake_safe_puts: uses of foreign fn lib::puts increased: 0 -> 1
+lib::fake_safe_puts: raw pointer types in signature increased: 0 -> 1
 lib::deref_ptr: raw pointer derefs increased: 0 -> 1
+lib::deref_ptr: raw pointer types in signature increased: 0 -> 1
 lib::f7: int-to-pointer casts increased: 0 -> 1
 lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -7,7 +7,7 @@ lib::fake_safe_puts: uses of foreign fn lib::puts increased: 0 -> 1
 lib::fake_safe_puts: raw pointer types in signature increased: 0 -> 1
 lib::deref_ptr: raw pointer derefs increased: 0 -> 1
 lib::deref_ptr: raw pointer types in signature increased: 0 -> 1
-lib::f7: int-to-pointer casts increased: 0 -> 1
+lib::f7a: int-to-pointer casts increased: 0 -> 1
 lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true
 lib::S: field x raw pointer count increased: 0 -> 1


### PR DESCRIPTION
Now counts raw pointers (including `NonNull<T>`) in fields and signatures, and counts int-to-pointer casts in functions.  We initially added only the basic raw pointer checks, but the agent often hid pointers by switching to `NonNull<T>` or by replacing the pointer with `usize` and casting at every use site, so now we have extra checks for those cases as well.

This also includes a couple small fixes:
* Allows calls to the unsafe function `Arguments::new` inside `writeln!`.  This was previously allowed inside `println!`, but the detection for that didn't work for `writeln!` (which is in `core` rather than `std`).
* Include a `total_unsafe` count in the output for each function.  This allows CRISP to easily identify which functions contain unsafe code of some kind.