### PR TITLE
Run cargo fix before safety loop to clear transpiler warnings

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -256,10 +256,14 @@ def do_main(args, cfg):
 
     # Auto-fix compiler warnings (e.g. unused imports) before the safety loop, so
     # they don't pollute every iteration's build output and waste tokens.
-    n_fixed = w.cargo_fix(n_code)
-    if n_fixed.node_id() != n_code.node_id():
-        w.accept(n_fixed, ('main', 'cargo_fix'))
-        n_code = n_fixed
+    n_code = w.cargo_fix(n_code)
+    if not w.cargo_check_json_op(n_code).passed:
+        print('error: build failed after cargo fix')
+        return
+    if not w.test(n_code, n_c_code):
+        print('error: tests failed after cargo fix')
+        return
+    w.accept(n_code, ('main', 'cargo_fix'))
 
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
 

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -254,6 +254,13 @@ def do_main(args, cfg):
         return
     w.accept(n_code, ('main', 'split_ffi'))
 
+    # Auto-fix compiler warnings (e.g. unused imports) before the safety loop, so
+    # they don't pollute every iteration's build output and waste tokens.
+    n_fixed = w.cargo_fix(n_code)
+    if n_fixed.node_id() != n_code.node_id():
+        w.accept(n_fixed, ('main', 'cargo_fix'))
+        n_code = n_fixed
+
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
 
 

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -16,6 +16,7 @@ from .mvir import (
     CompileCommandsOpNode, FindUnsafeAnalysisNode, CargoCheckJsonAnalysisNode,
     InlineErrorsOpNode, DefNode, CrateNode, SplitOpNode, MergeOpNode,
     RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
+    CargoFixOpNode,
 )
 from .sandbox import Sandbox, run_sandbox
 
@@ -173,6 +174,41 @@ def cargo_check_json(cfg: Config, mvir: MVIR, code: TreeNode) -> CargoCheckJsonA
             code = code.node_id(),
             exit_code = exit_code,
             json = n_json.node_id(),
+            body = logs,
+            )
+    mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
+    return n_op
+
+@analysis
+def cargo_fix(cfg: Config, mvir: MVIR, old_code: TreeNode) -> CargoFixOpNode:
+    """
+    Run `cargo fix` to auto-apply compiler suggestions (e.g. removing unused
+    imports).  On success, `new_code` is the fixed tree; on failure it equals
+    `old_code`.
+    """
+    rust_path_rel = cfg.relative_path(cfg.transpile.output_dir)
+    cmd = 'cd %s && cargo fix --allow-dirty --allow-no-vcs --message-format=short' % \
+            shlex.quote(rust_path_rel)
+
+    with run_sandbox(cfg, mvir) as sb:
+        sb.checkout(old_code)
+        exit_code, logs = sb.run(cmd + ' 2>&1', shell=True, stream=True)
+
+        if exit_code == 0:
+            # Re-commit exactly the input file set, picking up in-place edits and
+            # skipping build artifacts (`target/`, `Cargo.lock`, ...).
+            new_files = {path: sb.commit_file(path).node_id()
+                    for path in old_code.files.keys()}
+            new_code = TreeNode.new(mvir, files=new_files)
+        else:
+            new_code = old_code
+
+    n_op = CargoFixOpNode.new(
+            mvir,
+            old_code = old_code.node_id(),
+            new_code = new_code.node_id(),
+            cmd = cmd,
+            exit_code = exit_code,
             body = logs,
             )
     mvir.set_tag('op_history', n_op.node_id(), n_op.kind)

--- a/crisp/analysis.py
+++ b/crisp/analysis.py
@@ -192,7 +192,7 @@ def cargo_fix(cfg: Config, mvir: MVIR, old_code: TreeNode) -> CargoFixOpNode:
 
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(old_code)
-        exit_code, logs = sb.run(cmd + ' 2>&1', shell=True, stream=True)
+        exit_code, logs = sb.run(cmd, shell=True, stream=True)
 
         if exit_code == 0:
             # Re-commit exactly the input file set, picking up in-place edits and

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -803,6 +803,20 @@ class EditOpNode(Node):
     old_code = property(lambda self: self._metadata['old_code'])
     new_code = property(lambda self: self._metadata['new_code'])
 
+class CargoFixOpNode(Node):
+    KIND = 'cargo_fix_op'
+    old_code: Metadata[NodeId]
+    # `new_code` equals `old_code` when the fix failed or changed nothing.
+    new_code: Metadata[NodeId]
+    cmd: Metadata[str]
+    exit_code: Metadata[int]
+    # `body` stores the log output
+
+    old_code = property(lambda self: self._metadata['old_code'])
+    new_code = property(lambda self: self._metadata['new_code'])
+    cmd = property(lambda self: self._metadata['cmd'])
+    exit_code = property(lambda self: self._metadata['exit_code'])
+
 
 class DefNode(Node):
     KIND = 'def'
@@ -923,6 +937,7 @@ NODE_CLASSES = [
     FindUnsafe2AnalysisNode,
     CheckUnsafe2AnalysisNode,
     EditOpNode,
+    CargoFixOpNode,
 
     DefNode,
     CrateNode,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -19,6 +19,7 @@ from .mvir import (
     CargoCheckJsonAnalysisNode, EditOpNode, WorkflowStepInputsNode,
     WorkflowStepNode, SplitOpNode, MergeOpNode, CrateNode, DefNode,
     RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
+    CargoFixOpNode,
 )
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir
@@ -723,6 +724,15 @@ class Workflow:
             test_cmd = 'true'
         n = analysis.run_tests(self.cfg, self.mvir, code, c_code, test_cmd)
         return n
+
+    @step
+    def cargo_fix(self, code: TreeNode) -> TreeNode:
+        n = self.cargo_fix_op(code)
+        return self.mvir.node(n.new_code)
+
+    @step
+    def cargo_fix_op(self, code: TreeNode) -> CargoFixOpNode:
+        return analysis.cargo_fix(self.cfg, self.mvir, code)
 
     @step
     def cargo_check_json(self, code: TreeNode) -> list[dict]:


### PR DESCRIPTION
Libexpat spews 240 warnings each time the agent compiles the Rust. Cargo fix removes ~95% of the warnings so the log becomes shorter and we fill up the LLM context less.  