### PR TITLE
Add random targeting mode for agent

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -326,7 +326,42 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
         try:
             match args.llm_mode:
                 case 'agent':
-                    n_new_code, n_plans = w.agent_safety(n_code, n_c_code, n_plans)
+                    match consecutive_failures:
+                        case 0 | 1:
+                            suffix = None
+                        case 2 | 3:
+                            # Previous steps failed to make progress on
+                            # `unsafe`.  We've seen the agent sometimes just do
+                            # refactoring or other general cleanup that doesn't
+                            # directly reduce unsafe.  This is actually
+                            # desirable, but if it goes on too long, we add a
+                            # reminder to focus on reducing unsafety.
+                            suffix = (
+                                'Remember, your primary goal is to reduce '
+                                'the amount of unsafe code. '
+                                'Try to remove at least one unsafe operation '
+                                'or `unsafe fn`/`static mut` qualifier '
+                                'from the core implementation code.'
+                            )
+                        case n:
+                            # Last-ditch attempt to get the agent to make
+                            # progress.  This may be too strongly worded, to
+                            # the point of encouraging cheating (such as moving
+                            # unsafe operations into FFI wrappers).
+                            suffix = (
+                                'Remember, your primary goal is to reduce '
+                                'the amount of unsafe code. '
+                                f'Your past {n} attempts failed to remove '
+                                'any unsafe operations. '
+                                'You MUST remove at least one unsafe operation '
+                                'or `unsafe fn`/`static mut` qualifier '
+                                'from the core implementation code '
+                                '(NOT from FFI entry points), '
+                                'or this run will be terminated.'
+                            )
+
+                    n_new_code, n_plans = w.agent_safety(n_code, n_c_code, n_plans,
+                        prompt_suffix = suffix)
                     n_op_test = w.test_op(n_new_code, n_c_code)
                     n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
                     if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -7,6 +7,7 @@ import pathlib
 from pathlib import Path
 from pathspec import PathSpec, GitIgnoreSpec
 import pathspec.util
+import random
 import re
 import requests
 import stat
@@ -24,7 +25,10 @@ from .mvir import MVIR, NodeId, FileNode, TreeNode, LlmOpNode, \
     CodexAgentOpNode
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir, set_keep_work_dir
-from .workflow import Workflow
+from .workflow import (
+    Workflow, OutOfFuelError, AgentTargetField, AgentTargetFunction,
+    AgentTargetOther,
+)
 
 
 ARG_PARSE_EPILOG = '''
@@ -62,23 +66,25 @@ def parse_args():
     main.add_argument('--on-accept', metavar='COMMAND',
         help='Run COMMAND after each accepted CRISP state.')
     main.add_argument('--llm-mode',
-        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
+        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests',
+            'agent_rand_target'),
         default='default',
         help='which style of LLM-based rewriting to use')
     main.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
-            "requires --llm-mode=agent or --llm-mode=agent_sim_no_tests")
+            "requires --llm-mode=agent or similar")
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
     safety_loop.add_argument('node', nargs='?', default='current')
     safety_loop.add_argument('--llm-mode',
-        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests'),
+        choices=('default', 'no_ffi', 'agent', 'agent_sim_no_tests',
+            'agent_rand_target'),
         default='default',
         help='which style of LLM-based rewriting to use')
     safety_loop.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
-        "requires --llm-mode=agent or --llm-mode=agent_sim_no_tests")
+        "requires --llm-mode=agent or similar")
 
     repl = sub.add_parser('repl')
     repl.add_argument('--node', '-n', action='append', metavar='[NAME=]NODE',
@@ -129,8 +135,9 @@ def parse_args():
         help='check out files from this node into the sandbox')
 
     args = ap.parse_args()
-    if getattr(args, 'codex_login', False) and getattr(args, 'llm_mode', None) not in ('agent', 'agent_sim_no_tests'):
-        ap.error('--codex-login requires --llm-mode=agent or --llm-mode=agent_sim_no_tests')
+    AGENT_MODES = ('agent', 'agent_sim_no_tests', 'agent_rand_target')
+    if getattr(args, 'codex_login', False) and getattr(args, 'llm_mode', None) not in AGENT_MODES:
+        ap.error('--codex-login requires --llm-mode=agent or similar')
     return args
 
 
@@ -306,6 +313,10 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     consecutive_failures = 0
     n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
 
+    target_goal = None
+    safety_tries_per_target = int(os.environ.get('LLM_SAFETY_TRIES_PER_TARGET', 3))
+    target_goal_tries = 0
+
     prev_fuel = None
     while True:
         unsafe_count = w.count_unsafe2(n_code)
@@ -372,6 +383,18 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         n_code, n_c_code, n_plans,
                         prompt_suffix = suffix)
 
+                case 'agent_rand_target':
+                    if (target_goal is None or target_goal_tries == 0
+                            or target_goal_is_done(w, n_code, target_goal)):
+                        target_goal = pick_target_goal(w, n_code)
+                        target_goal_tries = safety_tries_per_target
+
+                    target_goal_tries -= 1
+
+                    n_new_code, n_new_plans = w.do_safety_step_agent(
+                        n_code, n_c_code, n_plans,
+                        target_goal = target_goal)
+
                 case 'agent_sim_no_tests':
                     n_new_code, n_new_plans = w.do_safety_step_agent_sim_no_tests(
                         n_code, n_c_code, n_plans)
@@ -408,6 +431,63 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     unsafe_count = w.count_unsafe2(n_code)
     print('final unsafe count = %d' % unsafe_count)
     print('final test exit code = %d' % n_op_test.exit_code)
+
+def pick_target_goal(w, n_code):
+    # Choose a `target_goal`.
+    function_targets = []
+    field_targets = []
+    for n_json_file in w.find_unsafe2_json_files(n_code):
+        j = n_json_file.body_json()
+        function_targets.extend(AgentTargetFunction(k)
+            for k,v in j['fns'].items()
+            if v['total_unsafe'] > 0 and not v['is_ffi_entry_point'])
+        for type_name, j_type in j['types'].items():
+            if 'type' in j_type['field_contains_raw_ptr']:
+                # This is a type alias, not a struct
+                # definition.  To avoid confusing prompting, we
+                # omit this from `target_fields`.  (Otherwise
+                # we would end up telling the agent to fix the
+                # "type" field of a non-struct.)
+                continue
+            field_targets.extend(AgentTargetField(type_name, k)
+                for k,v in j_type['field_contains_raw_ptr'].items()
+                if v > 0)
+
+    # Prefer fields over functions by giving them 5x normal
+    # weight.
+    functions_weight = len(function_targets)
+    fields_weight = 5 * len(field_targets)
+    target_lists = [function_targets, field_targets]
+    weights = [functions_weight, fields_weight]
+    if sum(weights) > 0:
+        print(f'choosing target with category weights {weights!r}')
+        target_list, = random.choices(target_lists, weights)
+        target_goal = random.choice(target_list)
+    else:
+        # We found no fields or functions, but `count_unsafe2`
+        # still reported some unsafe code.  Tell the agent to
+        # check the entire codebase for leftover unsafety.
+        target_goal = AgentTargetOther()
+
+    return target_goal
+
+def target_goal_is_done(w, n_code, target_goal):
+    total = 0
+    for n_json_file in w.find_unsafe2_json_files(n_code):
+        j = n_json_file.body_json()
+        match target_goal:
+            case AgentTargetField(struct, field):
+                j_struct = j['types'].get(struct)
+                if j_struct is not None:
+                    total += j_struct.get(field, 0)
+            case AgentTargetFunction(func):
+                j_func = j['fns'].get(func)
+                if j_func is not None:
+                    total += j_func['total_unsafe']
+            case AgentTargetOther():
+                total += j['total_unsafe']
+    return total == 0
+
 
 def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -292,6 +292,8 @@ def prior_agent_plans(mvir, n_code) -> TreeNode | None:
 def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     # Try at most this many times in total to make the code safe.
     llm_safety_tries = int(os.environ.get("LLM_SAFETY_TRIES", "3"))
+    w.fuel.give(llm_safety_tries)
+
     # If set, bail out if the LLM fails to improve safety of the code for
     # several consecutive iterations.  For example, if LLM_SAFETY_TRIES=100 and
     # LLM_SAFETY_MAX_CONSECUTIVE_FAILURES=3, the loop will stop if it makes no
@@ -304,7 +306,8 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     consecutive_failures = 0
     n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
 
-    for safety_try in range(llm_safety_tries):
+    prev_fuel = None
+    while True:
         unsafe_count = w.count_unsafe2(n_code)
         if unsafe_count == 0:
             break
@@ -322,6 +325,11 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
             if consecutive_failures >= max_consecutive_failures:
                 print(f'stopping due to {consecutive_failures} consecutive failures')
                 break
+
+        # Infinite loop detection
+        cur_fuel = w.fuel.fuel
+        assert cur_fuel != prev_fuel, 'safety loop ran without consuming any fuel'
+        prev_fuel = cur_fuel
 
         try:
             match args.llm_mode:
@@ -381,13 +389,17 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     assert False, f'unexpected llm_mode {mode!r}'
 
             if n_new_code is not None:
-                w.accept(n_new_code, ('main', 'safety', safety_try))
+                w.accept(n_new_code, ('main', 'safety', cur_fuel))
                 n_code = n_new_code
                 n_plans = n_new_plans
 
         except CrispError as e:
-            print(f'{args.llm_mode} safety attempt {safety_try} failed: {e}')
+            print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')
             traceback.print_exc()
+
+        except OutOfFuelError as e:
+            print(f'exiting due to lack of fuel: {e}')
+            break
 
     print('\n\n')
     print('final code = %s' % n_code.node_id())

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -360,54 +360,30 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                                 'or this run will be terminated.'
                             )
 
-                    n_new_code, n_plans = w.agent_safety(n_code, n_c_code, n_plans,
+                    n_new_code, n_new_plans = w.do_safety_step_agent(
+                        n_code, n_c_code, n_plans,
                         prompt_suffix = suffix)
-                    n_op_test = w.test_op(n_new_code, n_c_code)
-                    n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
-                    if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
-                        w.accept(n_new_code, ('main', 'safety', safety_try))
-                        n_code = n_new_code
-
-                    continue
 
                 case 'agent_sim_no_tests':
-                    # Don't provide the test code, so the agent can't
-                    # accidentally find the tests.  Note this has the side
-                    # effect of not providing the original C code, since we
-                    # don't currently distinguish test code from the rest of
-                    # the C code.
-                    n_new_code, n_plans = w.agent_safety_no_tests(n_code, n_plans)
-                    n_op_check = w.cargo_check_json_op(n_new_code)
-                    n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
-                    if n_op_check.passed and n_op_unsafe.exit_code == 0:
-                        w.accept(n_new_code, ('main', 'safety', safety_try))
-                        n_code = n_new_code
-
-                    # `agent_sim_no_tests` simulates the mode where no tests are
-                    # available and the only success criteria that CRISP can
-                    # check are whether the code builds or not.  We actually do
-                    # run the tests here, but if the accepted `n_code` ever
-                    # fails the tests, we bail out, on the assumption that
-                    # actually running CRISP with no tests on this input would
-                    # cause it to produce non-working code.
-                    n_op_test = w.test_op(n_code, n_c_code)
-                    assert n_op_test.exit_code == 0, \
-                        f'agent output failed tests: {n_op_test}'
-
-                    continue
+                    n_new_code, n_new_plans = w.do_safety_step_agent_sim_no_tests(
+                        n_code, n_c_code, n_plans)
 
                 case 'default':
-                    n_new_code = w.llm_safety(n_code)
+                    n_new_code = w.do_safety_step_llm(n_code, n_c_code)
+                    n_new_plans = n_plans
+
                 case 'no_ffi':
-                    n_new_code = w.llm_safety_no_ffi(n_code)
+                    n_new_code = w.do_safety_step_llm(n_code, n_c_code, no_ffi = True)
+                    n_new_plans = n_plans
+
                 case mode:
                     # `--llm-mode agent` should be handled at a higher level.
                     assert False, f'unexpected llm_mode {mode!r}'
 
-            n_new_code = safety_loop_validate_and_repair(w, n_code, n_new_code, n_c_code)
             if n_new_code is not None:
                 w.accept(n_new_code, ('main', 'safety', safety_try))
                 n_code = n_new_code
+                n_plans = n_new_plans
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {safety_try} failed: {e}')
@@ -421,56 +397,6 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     print('final unsafe count = %d' % unsafe_count)
     print('final test exit code = %d' % n_op_test.exit_code)
 
-def safety_loop_validate_and_repair(w, n_code, n_new_code, n_c_code) -> TreeNode | None:
-    """
-    Validate `n_new_code`.  If it fails validation, try to repair it.  Returns
-    a version that passes validation (after zero or more repair attempts), or
-    `None` if no passing version was found.
-    """
-    for repair_try in range(3):
-        try:
-            n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
-            if n_op_unsafe.exit_code != 0:
-                n_new_code = w.llm_repair_safety(n_new_code, n_op_unsafe)
-
-                n_op_unsafe = w.compare_unsafe2_op(n_code, n_new_code)
-                if n_op_unsafe.exit_code != 0:
-                    # If we failed to fix the unsafety, don't bother trying to
-                    # build or run tests.  This still counts as a repair
-                    # attempt.
-                    continue
-
-            n_op_check = w.cargo_check_json_op(n_new_code)
-            if not n_op_check.passed:
-                n_new_code = w.llm_repair_compile(n_new_code, n_op_check)
-
-                n_op_check = w.cargo_check_json_op(n_new_code)
-                if not n_op_check.passed:
-                    # If we failed to fix the compile errors, don't bother
-                    # trying to run tests.  This still counts as a repair
-                    # attempt.
-                    continue
-
-            n_op_test = w.test_op(n_new_code, n_c_code)
-            if n_op_test.exit_code != 0:
-                n_new_code = w.llm_repair(n_new_code, n_op_test)
-
-                n_op_test = w.test_op(n_new_code, n_c_code)
-                if n_op_test.exit_code != 0:
-                    continue
-
-            # All validation steps passed, so return the new version.
-            return n_new_code
-
-        except CrispError as e:
-            print(f'repair attempt {safety_try}.{repair_try} failed: {e}')
-            traceback.print_exc()
-
-    # None of the new versions passed the checks.
-    return None
-
-
-
 def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
     w = Workflow(cfg, mvir, codex_login=args.codex_login)
@@ -482,6 +408,7 @@ def do_safety_loop(args, cfg):
     n_code = mvir.node(code_node_id)
 
     safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
+
 
 def repl_locals(args, cfg, mvir, w):
     dct = dict(

--- a/crisp/git.py
+++ b/crisp/git.py
@@ -31,6 +31,9 @@ def get_repo(mvir: MVIR) -> pygit2.Repository:
 OP_NODE_KINDS = {
     mvir_module.LlmOpNode.KIND: ('old_code', 'new_code'),
     mvir_module.CodexAgentOpNode.KIND: ('old_code', 'new_code'),
+
+    # Backward compatibility with unmigrated `CodexAgentOp`s
+    'codex_agent_op': ('old_code', 'new_code'),
 }
 
 HISTORY_INDEX_KEYS = set((kind, new) for (kind, (old, new)) in OP_NODE_KINDS.items())

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -560,7 +560,7 @@ class Node:
                     else:
                         raise KeyError(
                             f'unknown node kind {cls_name!r} (migrated from {orig_cls_name!r})')
-                migration_func(metadata)
+                migration_func(mvir, metadata)
 
                 new_cls_name = metadata.get('kind')
                 if new_cls_name is None:
@@ -963,29 +963,29 @@ NODE_KIND_MAP = _build_node_kind_map(NODE_CLASSES)
 # maps the old metadata types to the new ones.  This allows newer versions of
 # CRISP to load older nodes without error.
 
-NODE_MIGRATION_MAP: dict[str, Callable[[dict[str, Any]], None]] = {}
+NODE_MIGRATION_MAP: dict[str, Callable[[MVIR, dict[str, Any]], None]] = {}
 
 def migration(old_kind: str):
-    def decorate(f: Callable[[dict[str, Any]], None]) -> Callable[[dict[str, Any]], None]:
+    def decorate(f: Callable[[MVIR, dict[str, Any]], None]) -> Callable[[dict[str, Any]], None]:
         assert old_kind not in NODE_MIGRATION_MAP, f'duplicate migration for {old_kind!r}'
         NODE_MIGRATION_MAP[old_kind] = f
         return f
     return decorate
 
 @migration('compile_commands_op')
-def migrate_compile_commands_op(metadata: dict[str, Any]):
+def migrate_compile_commands_op(mvir: MVIR, metadata: dict[str, Any]):
     metadata['kind'] = 'compile_commands_op_v2'
     # cmd: list[str]  ->  cmds: list[list[str]]
     metadata['cmds'] = [metadata.pop('cmd')]
 
 @migration('split_ffi_op')
-def migrate_split_ffi_op(metadata: dict[str, Any]):
+def migrate_split_ffi_op(mvir: MVIR, metadata: dict[str, Any]):
     metadata['kind'] = 'split_ffi_op_v2'
     # `commit` field was removed
     del metadata['commit']
 
 @migration('find_unsafe_analysis')
-def migrate_find_unsafe_analysis(metadata: dict[str, Any]):
+def migrate_find_unsafe_analysis(mvir: MVIR, metadata: dict[str, Any]):
     metadata['kind'] = 'find_unsafe_analysis_v2'
     # `commit` field was removed
     del metadata['commit']

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -687,7 +687,7 @@ class LlmOpNode(Node):
     response = property(lambda self: self._metadata['response'])
 
 class CodexAgentOpNode(Node):
-    KIND = 'codex_agent_op'
+    KIND = 'codex_agent_op_v2'
     old_code: Metadata[NodeId]
     new_code: Metadata[NodeId]
     raw_prompt: Metadata[NodeId]
@@ -994,3 +994,12 @@ def migrate_find_unsafe_analysis(mvir: MVIR, metadata: dict[str, Any]):
     metadata['exit_code'] = 0
     # `stderr` was renamed to `logs`
     metadata['logs'] = metadata['stderr']
+
+@migration('codex_agent_op')
+def migrate_codex_agent_op(mvir: MVIR, metadata: dict[str, Any]):
+    metadata['kind'] = 'codex_agent_op_v2'
+    # The `planning_files` field was added and merged without changing the
+    # `KIND`, so there may be `codex_agent_op` (old) nodes that actually
+    # already have the new field.
+    if 'planning_files' not in metadata:
+        metadata['planning_files'] = TreeNode.new(mvir, files = {}).node_id().raw

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -129,7 +129,7 @@ You are executing one iteration of a loop that will be re-invoked on the same co
 
 Then carry out the next step of the plan.
 
-HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code.
+HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
 
 {after_refactoring_instruction}
 
@@ -1077,6 +1077,7 @@ class Workflow:
         n_plans: TreeNode,
         # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
+        prompt_suffix: str | None = None,
     ) -> tuple[TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
@@ -1097,6 +1098,8 @@ class Workflow:
             cargo_dir_path = cargo_dir,
             after_refactoring_instruction = after_refactoring_instruction,
         )
+        if prompt_suffix is not None:
+            prompt = f'{prompt}\n\n{prompt_suffix}'
         return agent.run_rewrite(cfg, mvir, prompt, n_code,
             extra_code = extra_code,
             planning_files = n_plans,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1,4 +1,5 @@
 import cbor
+import dataclasses
 from dataclasses import dataclass
 from datetime import datetime
 import functools
@@ -118,27 +119,41 @@ New signatures:
 '''
 
 AGENT_SAFETY_PROMPT = '''
-Please refactor the Rust code in `{cargo_dir_path}` to avoid the use of `unsafe`, without changing its behavior.
+Please refactor the Rust code in `{cargo_dir_path}` to be safe, without changing its behavior.  The goal is to make the code fully safe, including migrating to safe memory management (`Box`/`Vec`/`Rc`) and  safe pointer types (`&T`/`&[T]`) throughout.
+
+{target_goal}
 
 You are executing one iteration of a loop that will be re-invoked on the same codebase until the unsafe count reaches zero or progress stalls. To carry state between iterations, maintain a planning file at `SAFETY_PLAN.md`:
 
-- **First, check whether `SAFETY_PLAN.md` already exists.** If it does, read it in full. It is your own notes from prior iterations. Use it to pick up where the previous run left off rather than starting over.
-- If `SAFETY_PLAN.md` does not exist, examine the codebase to identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fields) that uses `unsafe`, decide how to refactor it safely, and write that plan to `SAFETY_PLAN.md`.
+- **First, check whether `SAFETY_PLAN.md` already exists.** If it does, read it in full. It is your own notes from prior iterations.
+- If the existing `SAFETY_PLAN.md` applies to your current target, Use it to pick up where the previous run left off rather than starting over.
+- If `SAFETY_PLAN.md` does not exist, or if it exists but applies to an unrelated target, make a new plan for addressing the current target. Examine the target along with any callers/callees, use sites, and other related logic to understand the functionality it provides. Think about how to implement the same functionality using only safe Rust constructs. Then, plan out step by step how to migrate from the unsafe version to the safe equivalent. This plan may be as small as a single step if the target is simple, or it may be many steps if the target is complex or has many interactions. Once you have a plan, write it to `SAFETY_PLAN.md`.
 - **Before you finish, update `SAFETY_PLAN.md`** to reflect what you actually did this iteration, what is now complete, what remains, and any pitfalls or dead ends future iterations should avoid. Keep it concise — it is a working scratchpad, not a report.
-- If `SAFETY_PLAN.md` exists and all planned tasks have been completed, you should identify the next unit of code to work on and update the plan accordingly. This is a good time to trim and clean up the plan so it only contains the next steps and relevant notes. Pay close attention to pitfalls and dead ends such that future iterations do not repeat the same mistakes.
+- When rewriting the plan due to switching targets, pay close attention to any relevant pitfalls or dead ends recorded in the previous plan such that future iterations do not repeat the same mistakes. This is also a good time to trim and clean up the plan so it only contains the next steps and relevant notes.
 - If a planned unit turns out to be too complex or blocked by prerequisite work, update `SAFETY_PLAN.md` to record the blocker, split the work into smaller steps, and switch to the prerequisite or smaller step. Prefer steps that directly reduce the unsafe count, but preliminary safe refactors are acceptable when they are necessary to remove unsafe code in a later iteration.
 
 Then carry out the next step of the plan.
 
-HOWEVER, any function marked #[no_mangle] or #[export_name] is an FFI entry point, which means its signature must not be changed. If such a function has unsafe types (such as raw pointers) in its signature, you must leave them unmodified. You may still update the function body if needed to account for changes elsewhere in the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
+The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions.
+
+Implementation code may be freely refactored to improve safety. Here are some examples of useful changes to make:
+- Replace raw pointers with safe reference or smart pointer types, so that dereferences can be done safely.
+- Replace `static mut`s with non-`mut` and unions with enums so they can be accessed safely.
+- Eliminate calls to FFI imports and other unsafe functions. Try to replace these with suitable safe Rust operations, e.g. `printf` -> `println!`.
+- Remove the `unsafe` qualifier from functions that no longer need it, so that their callers can be made safe.
+
+For FFI entry points, the following rules apply:
+- You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
+- For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
+- Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
 
 {after_refactoring_instruction}
 
-Your changes must not introduce new unsafe code within implementation functions.  You can check your work using this command:
+Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:
 ```sh
 cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
-This will report an error for any unsafe code that was improperly added during your edits.
+This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''
@@ -151,6 +166,46 @@ After refactoring, make sure the code still passes the tests.  Run the tests usi
 AGENT_AFTER_REFACTORING_BUILD = '''
 After refactoring, make sure the code still builds.
 '''.strip()
+
+AGENT_TARGET_GOAL_FIELD = '''
+Your current target is the `{field_name}` field of `{struct_name}`, along with any similar or closely related fields.  Your goal is to change the field to use a safe type (such as `Box`, `Vec`, or `Rc`) instead of a raw pointer, and to update all uses of it to be as safe as possible (for example, use sites should not cast back to a raw pointer, since that defeats some of the safety checking).
+'''.strip()
+
+AGENT_TARGET_GOAL_FUNCTION = '''
+Your current target is the `{func_name}` function, along with any similar or closely related functions.  Your goal is to change the function in question to use only safe types (such as `Box`, `Vec`, or `Rc`) internally and in its signature, and to replace any unsafe FFI calls (e.g. `libc::printf`) with safe equivalents.  You should aim to make callees of the target function safe if it's feasible to do so, that way the entire call tree is safe.
+'''.strip()
+
+AGENT_TARGET_GOAL_OTHER = '''
+You currently have no specific target.  Scan the codebase for any remaining unsafe types, operations, or definitions (excluding FFI entry points) and identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fields) that uses `unsafe` for you to work on.
+'''.strip()
+
+class AgentTarget:
+    def prompt(self):
+        return self.PROMPT_FMT.format(**dataclasses.asdict(self))
+
+@dataclass(frozen = True)
+class AgentTargetField(AgentTarget):
+    """
+    Remove raw pointers from the type of a struct field.
+    """
+    struct_name: str
+    field_name: str
+    PROMPT_FMT = AGENT_TARGET_GOAL_FIELD
+
+@dataclass(frozen = True)
+class AgentTargetFunction(AgentTarget):
+    """
+    Make a function and all its callees safe.
+    """
+    func_name: str
+    PROMPT_FMT = AGENT_TARGET_GOAL_FUNCTION
+
+@dataclass(frozen = True)
+class AgentTargetOther(AgentTarget):
+    """
+    Remove any leftover unsafe from the codebase.
+    """
+    PROMPT_FMT = AGENT_TARGET_GOAL_OTHER
 
 
 _CRISP_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -801,8 +856,7 @@ class Workflow:
     def count_unsafe2(self, n_code: TreeNode) -> int:
         n_json = self.find_unsafe2_json(n_code)
         total = 0
-        for n_json_file_id in n_json.files.values():
-            n_json_file = self.mvir.node(n_json_file_id)
+        for n_json_file in self.find_unsafe2_json_files(n_code):
             total += n_json_file.body_json()['total_unsafe']
         print('%d unsafe operations remaining' % total)
         return total
@@ -811,6 +865,11 @@ class Workflow:
     def find_unsafe2_json(self, n_code: TreeNode) -> TreeNode:
         n_op = self.find_unsafe2_op(n_code)
         return self.mvir.node(n_op.unsafe_json)
+
+    @step
+    def find_unsafe2_json_files(self, n_code: TreeNode) -> list[FileNode]:
+        n_json = self.find_unsafe2_json(n_code)
+        return [self.mvir.node(file_id) for file_id in n_json.files.values()]
 
     @step
     def find_unsafe2_op(self, n_code: TreeNode) -> FindUnsafe2AnalysisNode:
@@ -1099,6 +1158,7 @@ class Workflow:
         # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
         prompt_suffix: str | None = None,
+        target_goal: AgentTarget = AgentTargetOther(),
     ) -> tuple[TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
@@ -1118,6 +1178,7 @@ class Workflow:
         prompt = AGENT_SAFETY_PROMPT.format(
             cargo_dir_path = cargo_dir,
             after_refactoring_instruction = after_refactoring_instruction,
+            target_goal = target_goal.prompt(),
         )
         if prompt_suffix is not None:
             prompt = f'{prompt}\n\n{prompt_suffix}'
@@ -1222,11 +1283,13 @@ class Workflow:
         n_test_code: TreeNode,
         n_plans: TreeNode,
         prompt_suffix: str | None = None,
+        target_goal: AgentTarget = AgentTargetOther(),
     ) -> tuple[TreeNode | None, TreeNode | None]:
         self.fuel.use()
 
         n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
-            prompt_suffix = prompt_suffix)
+            prompt_suffix = prompt_suffix,
+            target_goal = target_goal)
         # The change must pass tests, and must not regress any unsafe count.
         n_op_test = self.test_op(n_new_code, n_test_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1,4 +1,5 @@
 import cbor
+from dataclasses import dataclass
 from datetime import datetime
 import functools
 import inspect
@@ -155,6 +156,25 @@ After refactoring, make sure the code still builds.
 _CRISP_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
+@dataclass
+class FuelCounter:
+    desc: str
+    fuel: int = 0
+
+    def use(self):
+        if self.fuel == 0:
+            raise OutOfFuelError(self.desc)
+        else:
+            self.fuel -= 1
+
+    def give(self, amount):
+        if amount > self.fuel:
+            self.fuel = amount
+
+class OutOfFuelError(Exception):
+    pass
+
+
 def _print_step_value(prefix: str, x: Any):
     if isinstance(x, (tuple, list)):
         for i, y in enumerate(x):
@@ -236,6 +256,7 @@ class Workflow:
     def __init__(self, cfg: Config, mvir: MVIR, codex_login: bool = False):
         self.cfg = cfg
         self.mvir = mvir
+        self.fuel = FuelCounter('safety tries')
         self.codex_login = codex_login
         self._step_depth = 0
 
@@ -1185,6 +1206,8 @@ class Workflow:
         validation (as in `do_validate_and_repair`), or `None` if no passing
         version was found.
         """
+        self.fuel.use()
+
         if no_ffi:
             n_new_code = self.llm_safety_no_ffi(n_code)
         else:
@@ -1200,6 +1223,8 @@ class Workflow:
         n_plans: TreeNode,
         prompt_suffix: str | None = None,
     ) -> tuple[TreeNode | None, TreeNode | None]:
+        self.fuel.use()
+
         n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
             prompt_suffix = prompt_suffix)
         # The change must pass tests, and must not regress any unsafe count.
@@ -1217,6 +1242,8 @@ class Workflow:
         n_test_code: TreeNode,
         n_plans: TreeNode,
     ) -> tuple[TreeNode | None, TreeNode | None]:
+        self.fuel.use()
+
         # Don't provide the test code, so the agent can't
         # accidentally find the tests.  Note this has the side
         # effect of not providing the original C code, since we

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1117,3 +1117,126 @@ class Workflow:
         n_plans: TreeNode,
     ) -> tuple[TreeNode, TreeNode]:
         return self.agent_safety(n_code, None, n_plans, provide_test_cmd = False)
+
+
+    @step
+    def do_validate_and_repair(
+        self,
+        n_old_code: TreeNode,
+        n_new_code: TreeNode,
+        n_test_code: TreeNode,
+    ) -> TreeNode | None:
+        """
+        Validate `n_new_code`.  If it fails validation, try to repair it.
+        Returns a version that passes validation (after zero or more repair
+        attempts), or `None` if no passing version was found.
+        """
+        for repair_try in range(3):
+            try:
+                n_op_unsafe = self.compare_unsafe2_op(n_old_code, n_new_code)
+                if n_op_unsafe.exit_code != 0:
+                    # Unsafe check failed, so try to repair it.  If repair
+                    # succeeds, we proceed to the next check; otherwise, we try
+                    # again from the start of the loop.
+                    n_new_code = self.llm_repair_safety(n_new_code, n_op_unsafe)
+
+                    n_op_unsafe = self.compare_unsafe2_op(n_old_code, n_new_code)
+                    if n_op_unsafe.exit_code != 0:
+                        # If we failed to fix the unsafety, don't bother trying to
+                        # build or run tests.  This still counts as a repair
+                        # attempt.
+                        continue
+
+                n_op_check = self.cargo_check_json_op(n_new_code)
+                if not n_op_check.passed:
+                    n_new_code = self.llm_repair_compile(n_new_code, n_op_check)
+
+                    n_op_check = self.cargo_check_json_op(n_new_code)
+                    if not n_op_check.passed:
+                        continue
+
+                n_op_test = self.test_op(n_new_code, n_test_code)
+                if n_op_test.exit_code != 0:
+                    n_new_code = self.llm_repair(n_new_code, n_op_test)
+
+                    n_op_test = self.test_op(n_new_code, n_test_code)
+                    if n_op_test.exit_code != 0:
+                        continue
+
+                # All validation steps passed, so return the new version.
+                return n_new_code
+
+            except CrispError as e:
+                print(f'repair attempt {repair_try} failed: {e}')
+                traceback.print_exc()
+
+        # None of the new versions passed the checks.
+        return None
+
+    @step
+    def do_safety_step_llm(
+        self,
+        n_code: TreeNode,
+        n_test_code: TreeNode,
+        no_ffi: bool = False,
+    ) -> TreeNode | None:
+        """
+        Run one LLM safety rewriting step.  Returns a new version that passes
+        validation (as in `do_validate_and_repair`), or `None` if no passing
+        version was found.
+        """
+        if no_ffi:
+            n_new_code = self.llm_safety_no_ffi(n_code)
+        else:
+            n_new_code = self.llm_safety(n_code)
+
+        return self.do_validate_and_repair(n_code, n_new_code, n_test_code)
+
+    @step
+    def do_safety_step_agent(
+        self,
+        n_code: TreeNode,
+        n_test_code: TreeNode,
+        n_plans: TreeNode,
+        prompt_suffix: str | None = None,
+    ) -> tuple[TreeNode | None, TreeNode | None]:
+        n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
+            prompt_suffix = prompt_suffix)
+        # The change must pass tests, and must not regress any unsafe count.
+        n_op_test = self.test_op(n_new_code, n_test_code)
+        n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
+        if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
+            return n_new_code, n_plans
+        else:
+            return None, None
+
+    @step
+    def do_safety_step_agent_sim_no_tests(
+        self,
+        n_code: TreeNode,
+        n_test_code: TreeNode,
+        n_plans: TreeNode,
+    ) -> tuple[TreeNode | None, TreeNode | None]:
+        # Don't provide the test code, so the agent can't
+        # accidentally find the tests.  Note this has the side
+        # effect of not providing the original C code, since we
+        # don't currently distinguish test code from the rest of
+        # the C code.
+        n_new_code, n_plans = self.agent_safety_no_tests(n_code, n_plans)
+        n_op_check = self.cargo_check_json_op(n_new_code)
+        n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
+        if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
+            return None, None
+
+        # `agent_sim_no_tests` simulates the mode where no tests are
+        # available and the only success criteria that CRISP can
+        # check are whether the code builds or not.  We actually do
+        # run the tests here, but if the accepted `n_code` ever
+        # fails the tests, we bail out, on the assumption that
+        # actually running CRISP with no tests on this input would
+        # cause it to produce non-working code.
+        n_op_test = self.test_op(n_new_code, n_test_code)
+        assert n_op_test.exit_code == 0, \
+            f'agent output failed tests: {n_op_test}'
+
+        return n_new_code, n_plans

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -78,6 +78,8 @@ struct S {
     x: *const i32,
     // Error - NonNull also counts as a raw pointer type.
     y: NonNull<i32>,
+    // Error - NonNull is detected even underneath `Option`.
+    z: Option<NonNull<i32>>,
 }
 
 

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -68,4 +68,5 @@ unsafe extern "C" fn non_ffi3(p: *const i32) -> i32 {
 struct S {
     x: i32,
     y: i32,
+    z: i32,
 }

--- a/tools/find_unsafe2/tests/snapshots/example__run_example.snap
+++ b/tools/find_unsafe2/tests/snapshots/example__run_example.snap
@@ -12,3 +12,4 @@ lib::FFI2: raw pointer derefs increased: 0 -> 1
 lib::non_ffi3: FFI export flag changed: false -> true
 lib::S: field x raw pointer count increased: 0 -> 1
 lib::S: field y raw pointer count increased: 0 -> 1
+lib::S: field z raw pointer count increased: 0 -> 1


### PR DESCRIPTION
Adds `--llm-mode agent_rand_target`, which picks a random unsafe function or struct field and instructs the agent to focus its safety efforts there.  This seems to produce better results than letting it choose a target arbitrarily.  A new target is selected once the current target has been fixed (`find_unsafe2` reports no more unsafe operations / raw pointer types in that function / field) or the agent has gone more than 3 iterations (by default) on the same target without fixing it.

This branch contains a few other changes and last-minute fixes:
* Refactor to move the repair loop and other logic from `__main__.py` into `Workflow`.  The goal is to expose higher-level rewrite operations so they can be composed and reordered more easily.
* Add a "fuel" system that tracks iteration limits inside `Workflow` rather than in `__main__.py`.  This allows moving more loops into `Workflow` while still respecting global limits like `$LLM_SAFETY_TRIES`.
* Add MVIR migration logic to handle the addition of the `CodexAgentOpNode.planning_files` field from #124.
* In `--llm-mode agent` (but not the new `agent_rand_target`), append a warning to the prompt if the agent has gone too long without improving the unsafety metrics.  I'm not sure how useful this actually is, and we may end up removing it later.