### PR TITLE
WIP: Support resuming Codex agent session between turns

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -77,6 +77,10 @@ def parse_args():
     main.add_argument('--persist-codex-session', action='store_true',
         help='resume the previous Codex session on each agent turn; '
             'requires --llm-mode=agent or similar')
+    main.add_argument('--resume-prompt',
+        choices=('short', 'full'),
+        default='short',
+        help='prompt to use when resuming a persisted Codex session')
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
@@ -92,6 +96,10 @@ def parse_args():
     safety_loop.add_argument('--persist-codex-session', action='store_true',
         help='resume the previous Codex session on each agent turn; '
             'requires --llm-mode=agent or similar')
+    safety_loop.add_argument('--resume-prompt',
+        choices=('short', 'full'),
+        default='short',
+        help='prompt to use when resuming a persisted Codex session')
 
     repl = sub.add_parser('repl')
     repl.add_argument('--node', '-n', action='append', metavar='[NAME=]NODE',
@@ -148,6 +156,9 @@ def parse_args():
     if (getattr(args, 'persist_codex_session', False)
             and getattr(args, 'llm_mode', None) not in AGENT_MODES):
         ap.error('--persist-codex-session requires --llm-mode=agent or similar')
+    if (getattr(args, 'resume_prompt', 'short') != 'short'
+            and getattr(args, 'llm_mode', None) not in AGENT_MODES):
+        ap.error('--resume-prompt=full requires --llm-mode=agent or similar')
     return args
 
 
@@ -238,7 +249,8 @@ def do_main(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
     w = Workflow(cfg, mvir,
         codex_login=args.codex_login,
-        persist_codex_session=args.persist_codex_session)
+        persist_codex_session=args.persist_codex_session,
+        resume_prompt=args.resume_prompt)
 
     c_code_node_id = parse_node_id_arg(mvir, args.node)
     n_c_code = mvir.node(c_code_node_id)
@@ -609,7 +621,8 @@ def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
     w = Workflow(cfg, mvir,
         codex_login=args.codex_login,
-        persist_codex_session=args.persist_codex_session)
+        persist_codex_session=args.persist_codex_session,
+        resume_prompt=args.resume_prompt)
 
     c_code_node_id = parse_node_id_arg(mvir, args.c_code)
     n_c_code = mvir.node(c_code_node_id)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -74,13 +74,14 @@ def parse_args():
     main.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
             "requires --llm-mode=agent or similar")
-    main.add_argument('--persist-codex-session', action='store_true',
-        help='resume the previous Codex session on each agent turn; '
-            'requires --llm-mode=agent or similar')
+    main.add_argument('--resume-codex-session',
+        choices=('always', 'rejected', 'never'),
+        default='never',
+        help='when to resume Codex sessions in agent modes')
     main.add_argument('--resume-prompt',
         choices=('short', 'full'),
         default='short',
-        help='prompt to use when resuming a persisted Codex session')
+        help='prompt to use when resuming a Codex session')
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
@@ -93,13 +94,14 @@ def parse_args():
     safety_loop.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
         "requires --llm-mode=agent or similar")
-    safety_loop.add_argument('--persist-codex-session', action='store_true',
-        help='resume the previous Codex session on each agent turn; '
-            'requires --llm-mode=agent or similar')
+    safety_loop.add_argument('--resume-codex-session',
+        choices=('always', 'rejected', 'never'),
+        default='never',
+        help='when to resume Codex sessions in agent modes')
     safety_loop.add_argument('--resume-prompt',
         choices=('short', 'full'),
         default='short',
-        help='prompt to use when resuming a persisted Codex session')
+        help='prompt to use when resuming a Codex session')
 
     repl = sub.add_parser('repl')
     repl.add_argument('--node', '-n', action='append', metavar='[NAME=]NODE',
@@ -153,9 +155,9 @@ def parse_args():
     AGENT_MODES = ('agent', 'agent_sim_no_tests', 'agent_rand_target')
     if getattr(args, 'codex_login', False) and getattr(args, 'llm_mode', None) not in AGENT_MODES:
         ap.error('--codex-login requires --llm-mode=agent or similar')
-    if (getattr(args, 'persist_codex_session', False)
+    if (getattr(args, 'resume_codex_session', 'never') != 'never'
             and getattr(args, 'llm_mode', None) not in AGENT_MODES):
-        ap.error('--persist-codex-session requires --llm-mode=agent or similar')
+        ap.error('--resume-codex-session requires --llm-mode=agent or similar')
     if (getattr(args, 'resume_prompt', 'short') != 'short'
             and getattr(args, 'llm_mode', None) not in AGENT_MODES):
         ap.error('--resume-prompt=full requires --llm-mode=agent or similar')
@@ -249,7 +251,7 @@ def do_main(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
     w = Workflow(cfg, mvir,
         codex_login=args.codex_login,
-        persist_codex_session=args.persist_codex_session,
+        resume_codex_session=args.resume_codex_session,
         resume_prompt=args.resume_prompt)
 
     c_code_node_id = parse_node_id_arg(mvir, args.node)
@@ -423,7 +425,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     consecutive_failures = 0
     n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
     n_agent_code = n_code
-    if w.persist_codex_session:
+    if w.resume_codex_session == 'always':
         n_codex_state = (
             prior_agent_codex_state(mvir, n_code)
             or TreeNode.new(mvir, files={})
@@ -463,6 +465,13 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
         try:
             match args.llm_mode:
                 case 'agent':
+                    should_resume_codex_session = (
+                        w.resume_codex_session == 'always'
+                        or (
+                            w.resume_codex_session == 'rejected'
+                            and n_resume_prompt_override is not None
+                        )
+                    )
                     match consecutive_failures:
                         case 0 | 1:
                             suffix = None
@@ -508,11 +517,19 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         w.do_safety_step_agent(
                             n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
                             prompt_suffix = suffix,
+                            resume_codex_session = should_resume_codex_session,
                             resume_prompt_override = n_resume_prompt_override,
                         )
                     )
 
                 case 'agent_rand_target':
+                    should_resume_codex_session = (
+                        w.resume_codex_session == 'always'
+                        or (
+                            w.resume_codex_session == 'rejected'
+                            and n_resume_prompt_override is not None
+                        )
+                    )
                     if (target_goal is None or target_goal_tries == 0
                             or target_goal_is_done(w, n_code, target_goal)):
                         target_goal = pick_target_goal(w, n_code)
@@ -531,11 +548,19 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         w.do_safety_step_agent(
                             n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
                             target_goal = target_goal,
+                            resume_codex_session = should_resume_codex_session,
                             resume_prompt_override = n_resume_prompt_override,
                         )
                     )
 
                 case 'agent_sim_no_tests':
+                    should_resume_codex_session = (
+                        w.resume_codex_session == 'always'
+                        or (
+                            w.resume_codex_session == 'rejected'
+                            and n_resume_prompt_override is not None
+                        )
+                    )
                     (
                         n_new_code,
                         n_new_plans,
@@ -546,6 +571,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     ) = (
                         w.do_safety_step_agent_sim_no_tests(
                             n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
+                            resume_codex_session = should_resume_codex_session,
                             resume_prompt_override = n_resume_prompt_override,
                         )
                     )
@@ -578,10 +604,19 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 n_new_agent_code = n_new_code
                 n_new_agent_plans = n_new_plans
             n_codex_state = n_new_codex_state
-            if w.persist_codex_session:
+            if w.resume_codex_session == 'always':
                 n_resume_prompt_override = n_new_resume_prompt_override
                 n_agent_code = n_new_agent_code
                 n_plans = n_new_agent_plans
+            elif w.resume_codex_session == 'rejected':
+                if n_new_resume_prompt_override is not None:
+                    n_resume_prompt_override = n_new_resume_prompt_override
+                    n_agent_code = n_new_agent_code
+                    n_plans = n_new_agent_plans
+                else:
+                    n_resume_prompt_override = None
+                    n_agent_code = n_code
+                    n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
             else:
                 n_resume_prompt_override = None
                 n_agent_code = n_code
@@ -664,7 +699,7 @@ def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
     w = Workflow(cfg, mvir,
         codex_login=args.codex_login,
-        persist_codex_session=args.persist_codex_session,
+        resume_codex_session=args.resume_codex_session,
         resume_prompt=args.resume_prompt)
 
     c_code_node_id = parse_node_id_arg(mvir, args.c_code)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -74,6 +74,9 @@ def parse_args():
     main.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
             "requires --llm-mode=agent or similar")
+    main.add_argument('--persist-codex-session', action='store_true',
+        help='resume the previous Codex session on each agent turn; '
+            'requires --llm-mode=agent or similar')
 
     safety_loop = sub.add_parser('safety-loop')
     safety_loop.add_argument('--c-code', default='c_code')
@@ -86,6 +89,9 @@ def parse_args():
     safety_loop.add_argument('--codex-login', action='store_true',
         help="use the host's `codex login` credentials instead of CRISP_API_KEY; "
         "requires --llm-mode=agent or similar")
+    safety_loop.add_argument('--persist-codex-session', action='store_true',
+        help='resume the previous Codex session on each agent turn; '
+            'requires --llm-mode=agent or similar')
 
     repl = sub.add_parser('repl')
     repl.add_argument('--node', '-n', action='append', metavar='[NAME=]NODE',
@@ -139,6 +145,9 @@ def parse_args():
     AGENT_MODES = ('agent', 'agent_sim_no_tests', 'agent_rand_target')
     if getattr(args, 'codex_login', False) and getattr(args, 'llm_mode', None) not in AGENT_MODES:
         ap.error('--codex-login requires --llm-mode=agent or similar')
+    if (getattr(args, 'persist_codex_session', False)
+            and getattr(args, 'llm_mode', None) not in AGENT_MODES):
+        ap.error('--persist-codex-session requires --llm-mode=agent or similar')
     return args
 
 
@@ -227,7 +236,9 @@ def parse_node_id(mvir, s):
 
 def do_main(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
-    w = Workflow(cfg, mvir, codex_login=args.codex_login)
+    w = Workflow(cfg, mvir,
+        codex_login=args.codex_login,
+        persist_codex_session=args.persist_codex_session)
 
     c_code_node_id = parse_node_id_arg(mvir, args.node)
     n_c_code = mvir.node(c_code_node_id)
@@ -288,6 +299,33 @@ def prior_agent_plans(mvir, n_code) -> TreeNode | None:
         case [ie]:
             op_node = mvir.node(ie.node_id)
             return mvir.node(op_node.planning_files)
+        case []:
+            return None
+        case _:
+            raise CrispError(
+                f'multiple Codex agent ops produced code node {n_code.node_id()}: '
+                + ', '.join(str(ie.node_id) for ie in matches)
+            )
+
+
+def prior_agent_codex_state(mvir, n_code) -> TreeNode | None:
+    # Look up the node which produced `n_code` and return its committed Codex
+    # session files.  This lets a resumed safety-loop continue from the Codex
+    # session that produced the starting code node.
+    matches = [
+        ie for ie in mvir.index(n_code.node_id())
+        if ie.kind == CodexAgentOpNode.KIND and ie.key == 'new_code'
+    ]
+
+    match matches:
+        case [ie]:
+            op_node = mvir.node(ie.node_id)
+            raw_output_files = mvir.node(op_node.raw_output_files)
+            return TreeNode.new(mvir, files={
+                path: node_id
+                for path, node_id in raw_output_files.files.items()
+                if path.startswith('.codex/sessions/') and path.endswith('.jsonl')
+            })
         case []:
             return None
         case _:
@@ -372,6 +410,13 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     best_unsafe_count = None
     consecutive_failures = 0
     n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
+    if w.persist_codex_session:
+        n_codex_state = (
+            prior_agent_codex_state(mvir, n_code)
+            or TreeNode.new(mvir, files={})
+        )
+    else:
+        n_codex_state = TreeNode.new(mvir, files={})
 
     target_goal = None
     target_goal_tries = 0
@@ -438,9 +483,12 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                                 'or this run will be terminated.'
                             )
 
-                    n_new_code, n_new_plans = w.do_safety_step_agent(
-                        n_code, n_c_code, n_plans,
-                        prompt_suffix = suffix)
+                    n_new_code, n_new_plans, n_new_codex_state = (
+                        w.do_safety_step_agent(
+                            n_code, n_c_code, n_plans, n_codex_state,
+                            prompt_suffix = suffix,
+                        )
+                    )
 
                 case 'agent_rand_target':
                     if (target_goal is None or target_goal_tries == 0
@@ -450,21 +498,29 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
                     target_goal_tries -= 1
 
-                    n_new_code, n_new_plans = w.do_safety_step_agent(
-                        n_code, n_c_code, n_plans,
-                        target_goal = target_goal)
+                    n_new_code, n_new_plans, n_new_codex_state = (
+                        w.do_safety_step_agent(
+                            n_code, n_c_code, n_plans, n_codex_state,
+                            target_goal = target_goal,
+                        )
+                    )
 
                 case 'agent_sim_no_tests':
-                    n_new_code, n_new_plans = w.do_safety_step_agent_sim_no_tests(
-                        n_code, n_c_code, n_plans)
+                    n_new_code, n_new_plans, n_new_codex_state = (
+                        w.do_safety_step_agent_sim_no_tests(
+                            n_code, n_c_code, n_plans, n_codex_state,
+                        )
+                    )
 
                 case 'default':
                     n_new_code = w.do_safety_step_llm(n_code, n_c_code)
                     n_new_plans = n_plans
+                    n_new_codex_state = n_codex_state
 
                 case 'no_ffi':
                     n_new_code = w.do_safety_step_llm(n_code, n_c_code, no_ffi = True)
                     n_new_plans = n_plans
+                    n_new_codex_state = n_codex_state
 
                 case mode:
                     # `--llm-mode agent` should be handled at a higher level.
@@ -474,6 +530,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 w.accept(n_new_code, ('main', 'safety', cur_fuel))
                 n_code = n_new_code
                 n_plans = n_new_plans
+            n_codex_state = n_new_codex_state
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')
@@ -550,7 +607,9 @@ def target_goal_is_done(w, n_code, target_goal):
 
 def do_safety_loop(args, cfg):
     mvir = MVIR(cfg.mvir_storage_dir, '.')
-    w = Workflow(cfg, mvir, codex_login=args.codex_login)
+    w = Workflow(cfg, mvir,
+        codex_login=args.codex_login,
+        persist_codex_session=args.persist_codex_session)
 
     c_code_node_id = parse_node_id_arg(mvir, args.c_code)
     n_c_code = mvir.node(c_code_node_id)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -432,6 +432,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
     target_goal = None
     target_goal_tries = 0
+    n_resume_prompt_override = None
 
     prev_fuel = None
     while True:
@@ -495,10 +496,16 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                                 'or this run will be terminated.'
                             )
 
-                    n_new_code, n_new_plans, n_new_codex_state = (
+                    (
+                        n_new_code,
+                        n_new_plans,
+                        n_new_codex_state,
+                        n_new_resume_prompt_override,
+                    ) = (
                         w.do_safety_step_agent(
                             n_code, n_c_code, n_plans, n_codex_state,
                             prompt_suffix = suffix,
+                            resume_prompt_override = n_resume_prompt_override,
                         )
                     )
 
@@ -510,17 +517,29 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
                     target_goal_tries -= 1
 
-                    n_new_code, n_new_plans, n_new_codex_state = (
+                    (
+                        n_new_code,
+                        n_new_plans,
+                        n_new_codex_state,
+                        n_new_resume_prompt_override,
+                    ) = (
                         w.do_safety_step_agent(
                             n_code, n_c_code, n_plans, n_codex_state,
                             target_goal = target_goal,
+                            resume_prompt_override = n_resume_prompt_override,
                         )
                     )
 
                 case 'agent_sim_no_tests':
-                    n_new_code, n_new_plans, n_new_codex_state = (
+                    (
+                        n_new_code,
+                        n_new_plans,
+                        n_new_codex_state,
+                        n_new_resume_prompt_override,
+                    ) = (
                         w.do_safety_step_agent_sim_no_tests(
                             n_code, n_c_code, n_plans, n_codex_state,
+                            resume_prompt_override = n_resume_prompt_override,
                         )
                     )
 
@@ -528,11 +547,13 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     n_new_code = w.do_safety_step_llm(n_code, n_c_code)
                     n_new_plans = n_plans
                     n_new_codex_state = n_codex_state
+                    n_new_resume_prompt_override = None
 
                 case 'no_ffi':
                     n_new_code = w.do_safety_step_llm(n_code, n_c_code, no_ffi = True)
                     n_new_plans = n_plans
                     n_new_codex_state = n_codex_state
+                    n_new_resume_prompt_override = None
 
                 case mode:
                     # `--llm-mode agent` should be handled at a higher level.
@@ -542,7 +563,9 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 w.accept(n_new_code, ('main', 'safety', cur_fuel))
                 n_code = n_new_code
                 n_plans = n_new_plans
+                n_new_resume_prompt_override = None
             n_codex_state = n_new_codex_state
+            n_resume_prompt_override = n_new_resume_prompt_override
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -422,6 +422,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     best_unsafe_count = None
     consecutive_failures = 0
     n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
+    n_agent_code = n_code
     if w.persist_codex_session:
         n_codex_state = (
             prior_agent_codex_state(mvir, n_code)
@@ -501,9 +502,11 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         n_new_plans,
                         n_new_codex_state,
                         n_new_resume_prompt_override,
+                        n_new_agent_code,
+                        n_new_agent_plans,
                     ) = (
                         w.do_safety_step_agent(
-                            n_code, n_c_code, n_plans, n_codex_state,
+                            n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
                             prompt_suffix = suffix,
                             resume_prompt_override = n_resume_prompt_override,
                         )
@@ -522,9 +525,11 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         n_new_plans,
                         n_new_codex_state,
                         n_new_resume_prompt_override,
+                        n_new_agent_code,
+                        n_new_agent_plans,
                     ) = (
                         w.do_safety_step_agent(
-                            n_code, n_c_code, n_plans, n_codex_state,
+                            n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
                             target_goal = target_goal,
                             resume_prompt_override = n_resume_prompt_override,
                         )
@@ -536,9 +541,11 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         n_new_plans,
                         n_new_codex_state,
                         n_new_resume_prompt_override,
+                        n_new_agent_code,
+                        n_new_agent_plans,
                     ) = (
                         w.do_safety_step_agent_sim_no_tests(
-                            n_code, n_c_code, n_plans, n_codex_state,
+                            n_agent_code, n_code, n_c_code, n_plans, n_codex_state,
                             resume_prompt_override = n_resume_prompt_override,
                         )
                     )
@@ -548,12 +555,16 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                     n_new_plans = n_plans
                     n_new_codex_state = n_codex_state
                     n_new_resume_prompt_override = None
+                    n_new_agent_code = n_new_code if n_new_code is not None else n_code
+                    n_new_agent_plans = n_new_plans
 
                 case 'no_ffi':
                     n_new_code = w.do_safety_step_llm(n_code, n_c_code, no_ffi = True)
                     n_new_plans = n_plans
                     n_new_codex_state = n_codex_state
                     n_new_resume_prompt_override = None
+                    n_new_agent_code = n_new_code if n_new_code is not None else n_code
+                    n_new_agent_plans = n_new_plans
 
                 case mode:
                     # `--llm-mode agent` should be handled at a higher level.
@@ -564,8 +575,17 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 n_code = n_new_code
                 n_plans = n_new_plans
                 n_new_resume_prompt_override = None
+                n_new_agent_code = n_new_code
+                n_new_agent_plans = n_new_plans
             n_codex_state = n_new_codex_state
-            n_resume_prompt_override = n_new_resume_prompt_override
+            if w.persist_codex_session:
+                n_resume_prompt_override = n_new_resume_prompt_override
+                n_agent_code = n_new_agent_code
+                n_plans = n_new_agent_plans
+            else:
+                n_resume_prompt_override = None
+                n_agent_code = n_code
+                n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -249,7 +249,7 @@ def run_rewrite(
             codex_prompt = SHORT_RESUME_PROMPT
 
         if codex_state is None:
-            print('codex session: fresh (--persist-codex-session disabled)')
+            print('codex session: fresh (--resume-codex-session=never for this turn)')
         elif session_id is not None:
             print(f'codex session: resume {session_id}')
         elif resume_last:

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -196,6 +196,7 @@ def run_rewrite(
     codex_login: bool = False,
     codex_state: TreeNode | None = None,
     resume_prompt: str = 'short',
+    resume_prompt_override: str | None = None,
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
 ) -> tuple[TreeNode, TreeNode, TreeNode]:
@@ -242,7 +243,9 @@ def run_rewrite(
         is_resume = session_id is not None or resume_last
 
         codex_prompt = prompt
-        if is_resume and resume_prompt == 'short':
+        if is_resume and resume_prompt_override is not None:
+            codex_prompt = resume_prompt_override
+        elif is_resume and resume_prompt == 'short':
             codex_prompt = SHORT_RESUME_PROMPT
 
         if codex_state is None:
@@ -254,7 +257,10 @@ def run_rewrite(
         else:
             print('codex session: fresh (no prior session state)')
         if is_resume:
-            print(f'codex resume prompt: {resume_prompt}')
+            if resume_prompt_override is not None:
+                print('codex resume prompt: rejection-feedback')
+            else:
+                print(f'codex resume prompt: {resume_prompt}')
 
         codex_cmd = _codex_command(
             'exec',

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -17,6 +17,14 @@ from .mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
 from .sandbox import run_sandbox
 
 AGENT_DEFAULT_MODEL = "gpt-5.5-2026-04-23"
+SHORT_RESUME_PROMPT = """
+Resume the Rust safety refactoring work.
+
+Continue reducing unsafe Rust while preserving behavior and ABI compatibility.
+Use the existing conversation context, current workspace state, and any
+SAFETY_PLAN.md notes to choose and complete the next useful step. Before
+finishing, update SAFETY_PLAN.md and run the required build and unsafe checks.
+""".strip()
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
 _UUID_RE = re.compile(
@@ -187,9 +195,13 @@ def run_rewrite(
     clean_cmds: list[list[str]] = [],
     codex_login: bool = False,
     codex_state: TreeNode | None = None,
+    resume_prompt: str = 'short',
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
 ) -> tuple[TreeNode, TreeNode, TreeNode]:
+    if resume_prompt not in ('short', 'full'):
+        raise ValueError(f'unknown resume_prompt mode {resume_prompt!r}')
+
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
         "the sandbox and could theoretically be leaked " \
@@ -227,6 +239,11 @@ def run_rewrite(
         if codex_state is not None and codex_state.files:
             session_id = _session_id_from_codex_state(mvir, codex_state)
             resume_last = session_id is None
+        is_resume = session_id is not None or resume_last
+
+        codex_prompt = prompt
+        if is_resume and resume_prompt == 'short':
+            codex_prompt = SHORT_RESUME_PROMPT
 
         if codex_state is None:
             print('codex session: fresh (--persist-codex-session disabled)')
@@ -236,10 +253,12 @@ def run_rewrite(
             print('codex session: resume --last --all')
         else:
             print('codex session: fresh (no prior session state)')
+        if is_resume:
+            print(f'codex resume prompt: {resume_prompt}')
 
         codex_cmd = _codex_command(
             'exec',
-            _codex_exec_args(prompt, session_id, resume_last),
+            _codex_exec_args(codex_prompt, session_id, resume_last),
             codex_login=codex_login,
         )
         print(codex_cmd)
@@ -311,7 +330,7 @@ def run_rewrite(
     n_op = CodexAgentOpNode.new(mvir,
         old_code = input_code.node_id(),
         new_code = output_code.node_id(),
-        raw_prompt = FileNode.new(mvir, prompt).node_id(),
+        raw_prompt = FileNode.new(mvir, codex_prompt).node_id(),
         exit_code = exit_code,
         raw_output_files = raw_output_files.node_id(),
         json_session = json_session_node_id,

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -2,9 +2,11 @@
 Rewrite operations using AI agent tools, such as codex-cli
 """
 
+import json
 import os
 from pathlib import Path
 import re
+from typing import Any
 
 from pathspec.pathspec import PathSpec
 
@@ -17,6 +19,17 @@ from .sandbox import run_sandbox
 AGENT_DEFAULT_MODEL = "gpt-5.5-2026-04-23"
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+class CodexAgentError(CrispError):
+    def __init__(self, message: str, codex_state: TreeNode):
+        super().__init__(message)
+        self.codex_state = codex_state
+
 
 def _snapshot_to_family_alias(model: str) -> str:
     """
@@ -96,6 +109,73 @@ def _inject_codex_auth(sb):
     sb.checkout_file_untracked('.codex/auth.json', auth_bytes)
 
 
+def _walk_json_values(x: Any):
+    if isinstance(x, dict):
+        for v in x.values():
+            yield from _walk_json_values(v)
+    elif isinstance(x, list):
+        for v in x:
+            yield from _walk_json_values(v)
+    elif isinstance(x, str):
+        yield x
+
+
+def _session_ids_from_jsonl(body: bytes) -> set[str]:
+    meta_ids = set()
+    fallback_ids = set()
+    for raw_line in body.splitlines():
+        try:
+            line = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+
+        if isinstance(line, dict) and line.get('type') == 'session_meta':
+            payload = line.get('payload')
+            if isinstance(payload, dict):
+                session_id = payload.get('id')
+                if isinstance(session_id, str) and _UUID_RE.fullmatch(session_id):
+                    meta_ids.add(session_id)
+
+        for value in _walk_json_values(line):
+            if (m := _UUID_RE.fullmatch(value)) is not None:
+                fallback_ids.add(m.group(0))
+
+    return meta_ids or fallback_ids
+
+
+def _session_id_from_codex_state(mvir: MVIR, codex_state: TreeNode) -> str | None:
+    ids = set()
+    for path, node_id in codex_state.files.items():
+        if not (path.startswith('.codex/sessions/') and path.endswith('.jsonl')):
+            continue
+
+        ids.update(_UUID_RE.findall(path))
+        ids.update(_session_ids_from_jsonl(mvir.node(node_id).body()))
+
+    match sorted(ids):
+        case []:
+            return None
+        case [session_id]:
+            return session_id
+        case many:
+            print(
+                'warning: found multiple Codex session ids in persisted state '
+                f'{many}; falling back to `codex exec resume --last --all`')
+            return None
+
+
+def _codex_exec_args(prompt: str, session_id: str | None, resume_last: bool) -> list[str]:
+    common_args = [
+        '--dangerously-bypass-approvals-and-sandbox',
+        '--skip-git-repo-check',
+    ]
+    if session_id is not None:
+        return ['resume', *common_args, session_id, prompt]
+    if resume_last:
+        return ['resume', *common_args, '--last', '--all', prompt]
+    return [*common_args, prompt]
+
+
 def run_rewrite(
     cfg: Config,
     mvir: MVIR,
@@ -106,9 +186,10 @@ def run_rewrite(
     cwd: str = '.',
     clean_cmds: list[list[str]] = [],
     codex_login: bool = False,
+    codex_state: TreeNode | None = None,
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
-) -> tuple[TreeNode, TreeNode]:
+) -> tuple[TreeNode, TreeNode, TreeNode]:
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
         "the sandbox and could theoretically be leaked " \
@@ -131,6 +212,8 @@ def run_rewrite(
             sb.checkout(n)
         if planning_files is not None:
             sb.checkout(planning_files)
+        if codex_state is not None:
+            sb.checkout(codex_state)
 
         if codex_login:
             print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
@@ -139,11 +222,26 @@ def run_rewrite(
         codex_dir = sb.join(".codex")
         mkdir_codex = ['mkdir', '-p', codex_dir]
 
-        codex_cmd = _codex_command('exec', [
-            '--dangerously-bypass-approvals-and-sandbox',
-            '--skip-git-repo-check',
-            prompt,
-        ], codex_login=codex_login)
+        session_id = None
+        resume_last = False
+        if codex_state is not None and codex_state.files:
+            session_id = _session_id_from_codex_state(mvir, codex_state)
+            resume_last = session_id is None
+
+        if codex_state is None:
+            print('codex session: fresh (--persist-codex-session disabled)')
+        elif session_id is not None:
+            print(f'codex session: resume {session_id}')
+        elif resume_last:
+            print('codex session: resume --last --all')
+        else:
+            print('codex session: fresh (no prior session state)')
+
+        codex_cmd = _codex_command(
+            'exec',
+            _codex_exec_args(prompt, session_id, resume_last),
+            codex_login=codex_login,
+        )
         print(codex_cmd)
         all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 
@@ -160,7 +258,7 @@ def run_rewrite(
 
             # TODO: ensure API key doesn't get included in the AgentOpNode
             if exit_code != 0:
-                raise CrispError(f'codex-cli failed: exit code {exit_code}')
+                break
 
         ignore_lines = [
             '__pycache__/',
@@ -176,6 +274,7 @@ def run_rewrite(
 
     output_files = {}
     json_session_files = []
+    output_codex_state_files = {}
     output_plan_files = {}
     for path, node_id in raw_output_files.files.items():
         if any(path in n.files for n in extra_code):
@@ -192,6 +291,7 @@ def run_rewrite(
         elif path.startswith('.codex/sessions/') and path.endswith('.jsonl'):
             # This is a Codex session log file.
             json_session_files.append(node_id)
+            output_codex_state_files[path] = node_id
         elif Path(path).name in ['PLAN.md', 'SAFETY_PLAN.md']:
             # if the agent created a SAFETY_PLAN.md file, carry it over to future steps but
             # don't include it in the main output since it's not source code.
@@ -207,6 +307,7 @@ def run_rewrite(
 
     output_code = TreeNode.new(mvir, files=output_files)
     output_plans = TreeNode.new(mvir, files=output_plan_files)
+    output_codex_state = TreeNode.new(mvir, files=output_codex_state_files)
     n_op = CodexAgentOpNode.new(mvir,
         old_code = input_code.node_id(),
         new_code = output_code.node_id(),
@@ -220,4 +321,12 @@ def run_rewrite(
     # Record operations and timestamps in the `op_history` reflog.
     mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
 
-    return (output_code, output_plans)
+    print(f'codex session files committed: {len(output_codex_state_files)}')
+
+    if exit_code != 0:
+        raise CodexAgentError(
+            f'codex-cli failed: exit code {exit_code}',
+            output_codex_state,
+        )
+
+    return (output_code, output_plans, output_codex_state)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -316,12 +316,14 @@ class Workflow:
         mvir: MVIR,
         codex_login: bool = False,
         persist_codex_session: bool = False,
+        resume_prompt: str = 'short',
     ):
         self.cfg = cfg
         self.mvir = mvir
         self.fuel = FuelCounter('safety tries')
         self.codex_login = codex_login
         self.persist_codex_session = persist_codex_session
+        self.resume_prompt = resume_prompt
         self._step_depth = 0
 
     def accept(self, code: TreeNode, reason = None):
@@ -1212,6 +1214,7 @@ class Workflow:
             codex_state=(
                 n_codex_state if self.persist_codex_session else None
             ),
+            resume_prompt=self.resume_prompt,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ],

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -350,8 +350,10 @@ class Workflow:
             'Resume the Rust safety refactoring work.',
             '',
             'Your previous refactoring attempt was rejected by CRISP. '
-            'The workspace has been reset to the last accepted code version, '
-            'but the prior attempt is still visible in this Codex session context.',
+            'The workspace contains the rejected candidate code so you can '
+            'continue iterating on it, but CRISP will continue comparing unsafe '
+            'counts against the last accepted baseline until a corrected change '
+            'passes validation.',
             '',
             'Review the failed check output below, then make a corrected change '
             'that continues reducing unsafe Rust while preserving behavior and '
@@ -1352,13 +1354,14 @@ class Workflow:
     def do_safety_step_agent(
         self,
         n_code: TreeNode,
+        n_baseline_code: TreeNode,
         n_test_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
         resume_prompt_override: str | None = None,
-    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None]:
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None, TreeNode, TreeNode]:
         self.fuel.use()
 
         try:
@@ -1369,13 +1372,13 @@ class Workflow:
                 resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety failed: {e}; preserving Codex session state')
-            return None, None, e.codex_state, None
+            return None, None, e.codex_state, None, n_code, n_plans
 
         # The change must pass tests, and must not regress any unsafe count.
         n_op_test = self.test_op(n_new_code, n_test_code)
-        n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
+        n_op_unsafe = self.compare_unsafe2_op(n_baseline_code, n_new_code)
         if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
-            return n_new_code, n_plans, n_codex_state, None
+            return n_new_code, n_plans, n_codex_state, None, n_new_code, n_plans
         else:
             failed_checks = []
             if n_op_test.exit_code != 0:
@@ -1393,17 +1396,18 @@ class Workflow:
                     n_op_unsafe.body_str(),
                 ))
             feedback = self._agent_rejection_feedback(failed_checks)
-            return None, None, n_codex_state, feedback
+            return None, None, n_codex_state, feedback, n_new_code, n_plans
 
     @step
     def do_safety_step_agent_sim_no_tests(
         self,
         n_code: TreeNode,
+        n_baseline_code: TreeNode,
         n_test_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
         resume_prompt_override: str | None = None,
-    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None]:
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None, TreeNode, TreeNode]:
         self.fuel.use()
 
         # Don't provide the test code, so the agent can't
@@ -1417,10 +1421,10 @@ class Workflow:
                 resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety_no_tests failed: {e}; preserving Codex session state')
-            return None, None, e.codex_state, None
+            return None, None, e.codex_state, None, n_code, n_plans
 
         n_op_check = self.cargo_check_json_op(n_new_code)
-        n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
+        n_op_unsafe = self.compare_unsafe2_op(n_baseline_code, n_new_code)
         if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
             failed_checks = []
             if not n_op_check.passed:
@@ -1438,7 +1442,7 @@ class Workflow:
                     n_op_unsafe.body_str(),
                 ))
             feedback = self._agent_rejection_feedback(failed_checks)
-            return None, None, n_codex_state, feedback
+            return None, None, n_codex_state, feedback, n_new_code, n_plans
 
         # `agent_sim_no_tests` simulates the mode where no tests are
         # available and the only success criteria that CRISP can
@@ -1451,4 +1455,4 @@ class Workflow:
         assert n_op_test.exit_code == 0, \
             f'agent output failed tests: {n_op_test}'
 
-        return n_new_code, n_plans, n_codex_state, None
+        return n_new_code, n_plans, n_codex_state, None, n_new_code, n_plans

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -315,14 +315,17 @@ class Workflow:
         cfg: Config,
         mvir: MVIR,
         codex_login: bool = False,
-        persist_codex_session: bool = False,
+        resume_codex_session: str = 'never',
         resume_prompt: str = 'short',
     ):
+        if resume_codex_session not in ('always', 'rejected', 'never'):
+            raise ValueError(
+                f'unknown resume_codex_session mode {resume_codex_session!r}')
         self.cfg = cfg
         self.mvir = mvir
         self.fuel = FuelCounter('safety tries')
         self.codex_login = codex_login
-        self.persist_codex_session = persist_codex_session
+        self.resume_codex_session = resume_codex_session
         self.resume_prompt = resume_prompt
         self._step_depth = 0
 
@@ -1222,6 +1225,7 @@ class Workflow:
         provide_test_cmd: bool = True,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
+        resume_codex_session: bool = False,
         resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode, TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
@@ -1251,7 +1255,7 @@ class Workflow:
             planning_files = n_plans,
             codex_login=self.codex_login,
             codex_state=(
-                n_codex_state if self.persist_codex_session else None
+                n_codex_state if resume_codex_session else None
             ),
             resume_prompt=self.resume_prompt,
             resume_prompt_override=resume_prompt_override,
@@ -1267,11 +1271,13 @@ class Workflow:
         n_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
+        resume_codex_session: bool = False,
         resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode, TreeNode, TreeNode]:
         return self.agent_safety(
             n_code, None, n_plans, n_codex_state,
             provide_test_cmd = False,
+            resume_codex_session = resume_codex_session,
             resume_prompt_override = resume_prompt_override)
 
 
@@ -1360,6 +1366,7 @@ class Workflow:
         n_codex_state: TreeNode,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
+        resume_codex_session: bool = False,
         resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None, TreeNode, TreeNode]:
         self.fuel.use()
@@ -1369,6 +1376,7 @@ class Workflow:
                 n_code, n_test_code, n_plans, n_codex_state,
                 prompt_suffix = prompt_suffix,
                 target_goal = target_goal,
+                resume_codex_session = resume_codex_session,
                 resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety failed: {e}; preserving Codex session state')
@@ -1406,6 +1414,7 @@ class Workflow:
         n_test_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
+        resume_codex_session: bool = False,
         resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None, TreeNode, TreeNode]:
         self.fuel.use()
@@ -1418,6 +1427,7 @@ class Workflow:
         try:
             n_new_code, n_plans, n_codex_state = self.agent_safety_no_tests(
                 n_code, n_plans, n_codex_state,
+                resume_codex_session = resume_codex_session,
                 resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety_no_tests failed: {e}; preserving Codex session state')

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -342,6 +342,42 @@ class Workflow:
                     )
                     print(f'warning: on-accept hook cwd: {os.getcwd()}', file=sys.stderr)
 
+    def _agent_rejection_feedback(
+        self,
+        failed_checks: list[tuple[str, int, list[str] | str, str]],
+    ) -> str:
+        parts = [
+            'Resume the Rust safety refactoring work.',
+            '',
+            'Your previous refactoring attempt was rejected by CRISP. '
+            'The workspace has been reset to the last accepted code version, '
+            'but the prior attempt is still visible in this Codex session context.',
+            '',
+            'Review the failed check output below, then make a corrected change '
+            'that continues reducing unsafe Rust while preserving behavior and '
+            'ABI compatibility. Do not repeat the rejected change unless you '
+            'also address the reported failure.',
+            '',
+            'Failed checks:',
+        ]
+        for name, exit_code, cmd, output in failed_checks:
+            parts.extend([
+                '',
+                f'## {name}',
+                f'exit code: {exit_code}',
+                f'command: {cmd!r}',
+                '',
+                '```text',
+                output,
+                '```',
+            ])
+        parts.extend([
+            '',
+            'Before finishing, update SAFETY_PLAN.md and run the required build '
+            'and unsafe checks.',
+        ])
+        return '\n'.join(parts)
+
     @step
     def cc_cmake(self, c_code: TreeNode) -> FileNode:
         n_op_cc = self.cc_cmake_op(c_code)
@@ -1184,6 +1220,7 @@ class Workflow:
         provide_test_cmd: bool = True,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
+        resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode, TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
@@ -1215,6 +1252,7 @@ class Workflow:
                 n_codex_state if self.persist_codex_session else None
             ),
             resume_prompt=self.resume_prompt,
+            resume_prompt_override=resume_prompt_override,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ],
@@ -1227,9 +1265,12 @@ class Workflow:
         n_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
+        resume_prompt_override: str | None = None,
     ) -> tuple[TreeNode, TreeNode, TreeNode]:
         return self.agent_safety(
-            n_code, None, n_plans, n_codex_state, provide_test_cmd = False)
+            n_code, None, n_plans, n_codex_state,
+            provide_test_cmd = False,
+            resume_prompt_override = resume_prompt_override)
 
 
     @step
@@ -1316,25 +1357,43 @@ class Workflow:
         n_codex_state: TreeNode,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
-    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode]:
+        resume_prompt_override: str | None = None,
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None]:
         self.fuel.use()
 
         try:
             n_new_code, n_plans, n_codex_state = self.agent_safety(
                 n_code, n_test_code, n_plans, n_codex_state,
                 prompt_suffix = prompt_suffix,
-                target_goal = target_goal)
+                target_goal = target_goal,
+                resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety failed: {e}; preserving Codex session state')
-            return None, None, e.codex_state
+            return None, None, e.codex_state, None
 
         # The change must pass tests, and must not regress any unsafe count.
         n_op_test = self.test_op(n_new_code, n_test_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
-            return n_new_code, n_plans, n_codex_state
+            return n_new_code, n_plans, n_codex_state, None
         else:
-            return None, None, n_codex_state
+            failed_checks = []
+            if n_op_test.exit_code != 0:
+                failed_checks.append((
+                    'tests failed',
+                    n_op_test.exit_code,
+                    n_op_test.cmd,
+                    n_op_test.body_str(),
+                ))
+            if n_op_unsafe.exit_code != 0:
+                failed_checks.append((
+                    'unsafe check failed',
+                    n_op_unsafe.exit_code,
+                    n_op_unsafe.cmd,
+                    n_op_unsafe.body_str(),
+                ))
+            feedback = self._agent_rejection_feedback(failed_checks)
+            return None, None, n_codex_state, feedback
 
     @step
     def do_safety_step_agent_sim_no_tests(
@@ -1343,7 +1402,8 @@ class Workflow:
         n_test_code: TreeNode,
         n_plans: TreeNode,
         n_codex_state: TreeNode,
-    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode]:
+        resume_prompt_override: str | None = None,
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode, str | None]:
         self.fuel.use()
 
         # Don't provide the test code, so the agent can't
@@ -1353,15 +1413,32 @@ class Workflow:
         # the C code.
         try:
             n_new_code, n_plans, n_codex_state = self.agent_safety_no_tests(
-                n_code, n_plans, n_codex_state)
+                n_code, n_plans, n_codex_state,
+                resume_prompt_override = resume_prompt_override)
         except agent.CodexAgentError as e:
             print(f'agent_safety_no_tests failed: {e}; preserving Codex session state')
-            return None, None, e.codex_state
+            return None, None, e.codex_state, None
 
         n_op_check = self.cargo_check_json_op(n_new_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
-            return None, None, n_codex_state
+            failed_checks = []
+            if not n_op_check.passed:
+                failed_checks.append((
+                    'cargo check failed',
+                    n_op_check.exit_code,
+                    'cargo check',
+                    n_op_check.body_str(),
+                ))
+            if n_op_unsafe.exit_code != 0:
+                failed_checks.append((
+                    'unsafe check failed',
+                    n_op_unsafe.exit_code,
+                    n_op_unsafe.cmd,
+                    n_op_unsafe.body_str(),
+                ))
+            feedback = self._agent_rejection_feedback(failed_checks)
+            return None, None, n_codex_state, feedback
 
         # `agent_sim_no_tests` simulates the mode where no tests are
         # available and the only success criteria that CRISP can
@@ -1374,4 +1451,4 @@ class Workflow:
         assert n_op_test.exit_code == 0, \
             f'agent output failed tests: {n_op_test}'
 
-        return n_new_code, n_plans, n_codex_state
+        return n_new_code, n_plans, n_codex_state, None

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -310,11 +310,18 @@ def step(f):
 
 
 class Workflow:
-    def __init__(self, cfg: Config, mvir: MVIR, codex_login: bool = False):
+    def __init__(
+        self,
+        cfg: Config,
+        mvir: MVIR,
+        codex_login: bool = False,
+        persist_codex_session: bool = False,
+    ):
         self.cfg = cfg
         self.mvir = mvir
         self.fuel = FuelCounter('safety tries')
         self.codex_login = codex_login
+        self.persist_codex_session = persist_codex_session
         self._step_depth = 0
 
     def accept(self, code: TreeNode, reason = None):
@@ -1170,11 +1177,12 @@ class Workflow:
         n_code: TreeNode,
         n_test_code: TreeNode | None,
         n_plans: TreeNode,
+        n_codex_state: TreeNode,
         # If set, provide `cfg.test_command` to the agent, if it's available.
         provide_test_cmd: bool = True,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
-    ) -> tuple[TreeNode, TreeNode]:
+    ) -> tuple[TreeNode, TreeNode, TreeNode]:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
 
@@ -1201,6 +1209,9 @@ class Workflow:
             extra_code = extra_code,
             planning_files = n_plans,
             codex_login=self.codex_login,
+            codex_state=(
+                n_codex_state if self.persist_codex_session else None
+            ),
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ],
@@ -1212,8 +1223,10 @@ class Workflow:
         self,
         n_code: TreeNode,
         n_plans: TreeNode,
-    ) -> tuple[TreeNode, TreeNode]:
-        return self.agent_safety(n_code, None, n_plans, provide_test_cmd = False)
+        n_codex_state: TreeNode,
+    ) -> tuple[TreeNode, TreeNode, TreeNode]:
+        return self.agent_safety(
+            n_code, None, n_plans, n_codex_state, provide_test_cmd = False)
 
 
     @step
@@ -1297,21 +1310,28 @@ class Workflow:
         n_code: TreeNode,
         n_test_code: TreeNode,
         n_plans: TreeNode,
+        n_codex_state: TreeNode,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
-    ) -> tuple[TreeNode | None, TreeNode | None]:
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode]:
         self.fuel.use()
 
-        n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
-            prompt_suffix = prompt_suffix,
-            target_goal = target_goal)
+        try:
+            n_new_code, n_plans, n_codex_state = self.agent_safety(
+                n_code, n_test_code, n_plans, n_codex_state,
+                prompt_suffix = prompt_suffix,
+                target_goal = target_goal)
+        except agent.CodexAgentError as e:
+            print(f'agent_safety failed: {e}; preserving Codex session state')
+            return None, None, e.codex_state
+
         # The change must pass tests, and must not regress any unsafe count.
         n_op_test = self.test_op(n_new_code, n_test_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
-            return n_new_code, n_plans
+            return n_new_code, n_plans, n_codex_state
         else:
-            return None, None
+            return None, None, n_codex_state
 
     @step
     def do_safety_step_agent_sim_no_tests(
@@ -1319,7 +1339,8 @@ class Workflow:
         n_code: TreeNode,
         n_test_code: TreeNode,
         n_plans: TreeNode,
-    ) -> tuple[TreeNode | None, TreeNode | None]:
+        n_codex_state: TreeNode,
+    ) -> tuple[TreeNode | None, TreeNode | None, TreeNode]:
         self.fuel.use()
 
         # Don't provide the test code, so the agent can't
@@ -1327,11 +1348,17 @@ class Workflow:
         # effect of not providing the original C code, since we
         # don't currently distinguish test code from the rest of
         # the C code.
-        n_new_code, n_plans = self.agent_safety_no_tests(n_code, n_plans)
+        try:
+            n_new_code, n_plans, n_codex_state = self.agent_safety_no_tests(
+                n_code, n_plans, n_codex_state)
+        except agent.CodexAgentError as e:
+            print(f'agent_safety_no_tests failed: {e}; preserving Codex session state')
+            return None, None, e.codex_state
+
         n_op_check = self.cargo_check_json_op(n_new_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
-            return None, None
+            return None, None, n_codex_state
 
         # `agent_sim_no_tests` simulates the mode where no tests are
         # available and the only success criteria that CRISP can
@@ -1344,4 +1371,4 @@ class Workflow:
         assert n_op_test.exit_code == 0, \
             f'agent output failed tests: {n_op_test}'
 
-        return n_new_code, n_plans
+        return n_new_code, n_plans, n_codex_state

--- a/uv.lock
+++ b/uv.lock
@@ -219,27 +219,32 @@ source = { editable = "." }
 dependencies = [
     { name = "cbor" },
     { name = "docker" },
-    { name = "gepa" },
-    { name = "litellm" },
-    { name = "pandas" },
     { name = "pathspec" },
     { name = "pygit2" },
     { name = "requests" },
     { name = "toml" },
 ]
 
+[package.optional-dependencies]
+gepa = [
+    { name = "gepa" },
+    { name = "litellm" },
+    { name = "pandas" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "cbor", specifier = ">=1.0.0" },
     { name = "docker", specifier = ">=7.1.0" },
-    { name = "gepa", specifier = ">=0.1.1" },
-    { name = "litellm", specifier = ">=1.83.14" },
-    { name = "pandas", specifier = ">=3.0.2" },
+    { name = "gepa", marker = "extra == 'gepa'", specifier = ">=0.1.1" },
+    { name = "litellm", marker = "extra == 'gepa'", specifier = ">=1.83.14" },
+    { name = "pandas", marker = "extra == 'gepa'", specifier = ">=3.0.2" },
     { name = "pathspec", specifier = ">=1.0.4" },
     { name = "pygit2", specifier = ">=1.19.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "toml", specifier = ">=0.10.2" },
 ]
+provides-extras = ["gepa"]
 
 [[package]]
 name = "distro"


### PR DESCRIPTION
> NOTE: This PR is pure Codex output, I have written none of this by hand. I am still testing this out, and will not cleanup the code until after doing some test runs to figure out if this change is even useful.
>
> ~Also, this branch currently includes an unrelated change to fix the check-unsafe2 cargo command. Once I have tested that in a long-running CRISP session I'll split that off into its own PR.~

Add a couple of options for resuming the Codex session between turns of the CRISP loop:

- `--resume-codex-session={always,rejected,never}` - Specify when to resume the session:
  - `always` - Always resume, i.e. use one session for the entire translation.
  - `rejected` - Resume only on rejected changes to give the agent a chance to fix errors, but use a fresh session after a change is accepted.
  - `never` - Never resume, so use a fresh session for every turn of the loop. This is the current behavior on master.
- `--resume-prompt={short,full}` to either use a shortened prompt when resuming or just repeat the full prompt every time. I want to A/B test these two to see if we can observe any change in performance after context compaction is happening. My assumption is that if we don't repeat our instructions in the prompt, then the full context will be lost after compaction and we'll see the agent going off the rails more.