### PR TITLE
Use fresh target dir when running `cargo check-unsafe2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
         crate:
           - find_unsafe
           - find_unsafe2
+          - find_unsafe2/cargo_subcommands
           - merge_rust
           - related_decls
           - rust_analyzer_ext

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -154,8 +154,6 @@ Your changes must not introduce new unsafe code within implementation functions.
 cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
 This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
-
-NOTE: Do not run `cargo build` or any other `cargo` command at the same time as `check-unsafe2`, as this can cause `check-unsafe2` to fail to report increased unsafe counts.
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -154,6 +154,8 @@ Your changes must not introduce new unsafe code within implementation functions.
 cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
 This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
+
+NOTE: Do not run `cargo build` or any other `cargo` command at the same time as `check-unsafe2`, as this can cause `check-unsafe2` to fail to report increased unsafe counts.
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -472,6 +472,9 @@ dependencies = [
 [[package]]
 name = "find_unsafe2_cargo_subcommands"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "fixedbitset"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,6 +21,7 @@ log = "=0.4.28"
 env_logger = {version = "0.11.8", default-features = false, features = ["color", "auto-color", "humantime"]}
 itertools = "0.14.0"
 insta = { version = "1.46", features = ["json"] }
+tempfile = "3.27.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/tools/find_unsafe2/cargo_subcommands/Cargo.toml
+++ b/tools/find_unsafe2/cargo_subcommands/Cargo.toml
@@ -4,3 +4,4 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+tempfile.workspace = true

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -16,6 +16,27 @@ fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
+fn cargo_cmd(opt_toolchain: Option<&str>) -> Command {
+    let mut cmd = Command::new("cargo");
+    if let Some(toolchain) = opt_toolchain {
+        cmd.arg(format!("+{toolchain}"));
+    }
+    cmd
+}
+
+fn manifest_path_arg() -> Option<String> {
+    let mut args = env::args().skip(2);
+    while let Some(arg) = args.next() {
+        if arg == "--manifest-path" {
+            return args.next();
+        }
+        if let Some(value) = arg.strip_prefix("--manifest-path=") {
+            return Some(value.to_owned());
+        }
+    }
+    None
+}
+
 pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     let opt_toolchain = option_env!("RUSTUP_TOOLCHAIN");
 
@@ -50,10 +71,22 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     // different toolchain from the one `find_unsafe2` was built with.  If the parent toolchain is
     // too far apart in version, its `cargo` might be incompatible with `find_unsafe2`'s wrapped
     // `rustc`.
-    let mut cmd = Command::new("cargo");
-    if let Some(toolchain) = opt_toolchain {
-        cmd.arg(format!("+{toolchain}"));
+    let mut clean_cmd = cargo_cmd(opt_toolchain);
+    clean_cmd.arg("clean");
+    if let Some(manifest_path) = manifest_path_arg() {
+        clean_cmd.arg("--manifest-path").arg(manifest_path);
     }
+    clean_cmd.arg("--workspace");
+    eprintln!("exec: {clean_cmd:?}");
+    let status = clean_cmd.status().unwrap();
+    assert!(
+        status.success(),
+        "{:?} exited with code {:?}",
+        clean_cmd,
+        status
+    );
+
+    let mut cmd = cargo_cmd(opt_toolchain);
     cmd.arg("build")
         .args(env::args().skip(2))
         .env(LIB_PATH_VAR, new_lib_path)

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::path::{self, Path};
 use std::process::{self, Command};
-use std::os::unix::process::CommandExt;
 
 fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     let mut cmd = Command::new("rustc");
@@ -16,7 +15,7 @@ fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
-pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
+pub fn cargo_subcommand_main(wrapper_exe: &Path) {
     let opt_toolchain = option_env!("RUSTUP_TOOLCHAIN");
 
     // LD_LIBRARY_PATH handling
@@ -78,6 +77,10 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
         .env(SRC_DIR_VAR, src_dir_abs)
         .env(JSON_DIR_VAR, json_dir_abs);
     eprintln!("exec: {cmd:?}");
-    let err = cmd.exec();
-    panic!("exec failed: {:?}", err);
+    let status = cmd
+        .status()
+        .expect("Failed to run `cargo build` with RUSTC_WRAPPER");
+    if !status.success() {
+        panic!("Failed to run {}: {status}", wrapper_exe.display())
+    }
 }

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -70,9 +70,10 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
         cmd.arg(format!("+{toolchain}"));
     }
     cmd.arg("build")
+        .arg("--target-dir")
+        .arg(target_dir.path())
         .args(env::args().skip(2))
         .env(LIB_PATH_VAR, new_lib_path)
-        .env("CARGO_TARGET_DIR", target_dir.path())
         .env("RUSTC_WRAPPER", wrapper_exe)
         .env(SRC_DIR_VAR, src_dir_abs)
         .env(JSON_DIR_VAR, json_dir_abs);

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::{self, Path, PathBuf};
+use std::path::{self, Path};
 use std::process::{self, Command};
 use std::os::unix::process::CommandExt;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -1,8 +1,7 @@
 use std::env;
 use std::path::{self, Path};
 use std::process::{self, Command};
-#[cfg(unix)]
-use std::os::unix::process::ExitStatusExt;
+use std::os::unix::process::CommandExt;
 
 fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     let mut cmd = Command::new("rustc");

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -1,9 +1,8 @@
 use std::env;
-use std::fs;
 use std::path::{self, Path};
 use std::process::{self, Command};
-use std::os::unix::process::CommandExt;
-use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 
 fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     let mut cmd = Command::new("rustc");
@@ -58,15 +57,10 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     // `cargo check-unsafe2` then we won't report any increased unsafe counts. To
     // ensure that Cargo always builds the project, we use a temp dir as the target
     // dir, forcing a full build every time.
-    let timestamp_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let target_dir = env::temp_dir().join(format!(
-        "find_unsafe2-target-{}-{timestamp_nanos}",
-        process::id()
-    ));
-    fs::create_dir_all(&target_dir).unwrap();
+    let target_dir = tempfile::Builder::new()
+        .prefix("find_unsafe2-target-")
+        .tempdir()
+        .unwrap();
 
     // Use `cargo +toolchain` instead of `$CARGO` here in case the parent `cargo` process is from a
     // different toolchain from the one `find_unsafe2` was built with.  If the parent toolchain is
@@ -79,7 +73,7 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     cmd.arg("build")
         .args(env::args().skip(2))
         .env(LIB_PATH_VAR, new_lib_path)
-        .env("CARGO_TARGET_DIR", target_dir)
+        .env("CARGO_TARGET_DIR", target_dir.path())
         .env("RUSTC_WRAPPER", wrapper_exe)
         .env(SRC_DIR_VAR, src_dir_abs)
         .env(JSON_DIR_VAR, json_dir_abs);

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -18,19 +18,6 @@ fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
-fn fresh_target_dir() -> PathBuf {
-    let timestamp_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let target_dir = env::temp_dir().join(format!(
-        "find_unsafe2-target-{}-{timestamp_nanos}",
-        process::id()
-    ));
-    fs::create_dir_all(&target_dir).unwrap();
-    target_dir
-}
-
 pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     let opt_toolchain = option_env!("RUSTUP_TOOLCHAIN");
 
@@ -60,7 +47,26 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     let opt_json_dir = env::var_os(JSON_DIR_VAR);
     let json_dir = opt_json_dir.as_ref().map_or(Path::new("find_unsafe2_json"), |x| Path::new(x));
     let json_dir_abs = path::absolute(&json_dir).unwrap();
-    let target_dir = fresh_target_dir();
+
+    // Create a fresh target dir for each run to ensure that Cargo actually runs our
+    // rustc wrapper.
+    //
+    // If we try to run `cargo build` within the normal workspace and the workspace
+    // is clean (i.e. no changes have been made since the last `cargo build`), then
+    // `cargo build` is a no-op and never actually invokes our wrapper. This means
+    // that if the agent does `cargo build` right before (or at the same time as)
+    // `cargo check-unsafe2` then we won't report any increased unsafe counts. To
+    // ensure that Cargo always builds the project, we use a temp dir as the target
+    // dir, forcing a full build every time.
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let target_dir = env::temp_dir().join(format!(
+        "find_unsafe2-target-{}-{timestamp_nanos}",
+        process::id()
+    ));
+    fs::create_dir_all(&target_dir).unwrap();
 
     // Use `cargo +toolchain` instead of `$CARGO` here in case the parent `cargo` process is from a
     // different toolchain from the one `find_unsafe2` was built with.  If the parent toolchain is

--- a/tools/find_unsafe2/cargo_subcommands/src/lib.rs
+++ b/tools/find_unsafe2/cargo_subcommands/src/lib.rs
@@ -1,7 +1,9 @@
 use std::env;
-use std::path::{self, Path};
+use std::fs;
+use std::path::{self, Path, PathBuf};
 use std::process::{self, Command};
 use std::os::unix::process::CommandExt;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     let mut cmd = Command::new("rustc");
@@ -16,25 +18,17 @@ fn rustc_print_sysroot(opt_toolchain: Option<&str>) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
-fn cargo_cmd(opt_toolchain: Option<&str>) -> Command {
-    let mut cmd = Command::new("cargo");
-    if let Some(toolchain) = opt_toolchain {
-        cmd.arg(format!("+{toolchain}"));
-    }
-    cmd
-}
-
-fn manifest_path_arg() -> Option<String> {
-    let mut args = env::args().skip(2);
-    while let Some(arg) = args.next() {
-        if arg == "--manifest-path" {
-            return args.next();
-        }
-        if let Some(value) = arg.strip_prefix("--manifest-path=") {
-            return Some(value.to_owned());
-        }
-    }
-    None
+fn fresh_target_dir() -> PathBuf {
+    let timestamp_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let target_dir = env::temp_dir().join(format!(
+        "find_unsafe2-target-{}-{timestamp_nanos}",
+        process::id()
+    ));
+    fs::create_dir_all(&target_dir).unwrap();
+    target_dir
 }
 
 pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
@@ -66,30 +60,20 @@ pub fn cargo_subcommand_main(wrapper_exe: &Path) -> ! {
     let opt_json_dir = env::var_os(JSON_DIR_VAR);
     let json_dir = opt_json_dir.as_ref().map_or(Path::new("find_unsafe2_json"), |x| Path::new(x));
     let json_dir_abs = path::absolute(&json_dir).unwrap();
+    let target_dir = fresh_target_dir();
 
     // Use `cargo +toolchain` instead of `$CARGO` here in case the parent `cargo` process is from a
     // different toolchain from the one `find_unsafe2` was built with.  If the parent toolchain is
     // too far apart in version, its `cargo` might be incompatible with `find_unsafe2`'s wrapped
     // `rustc`.
-    let mut clean_cmd = cargo_cmd(opt_toolchain);
-    clean_cmd.arg("clean");
-    if let Some(manifest_path) = manifest_path_arg() {
-        clean_cmd.arg("--manifest-path").arg(manifest_path);
+    let mut cmd = Command::new("cargo");
+    if let Some(toolchain) = opt_toolchain {
+        cmd.arg(format!("+{toolchain}"));
     }
-    clean_cmd.arg("--workspace");
-    eprintln!("exec: {clean_cmd:?}");
-    let status = clean_cmd.status().unwrap();
-    assert!(
-        status.success(),
-        "{:?} exited with code {:?}",
-        clean_cmd,
-        status
-    );
-
-    let mut cmd = cargo_cmd(opt_toolchain);
     cmd.arg("build")
         .args(env::args().skip(2))
         .env(LIB_PATH_VAR, new_lib_path)
+        .env("CARGO_TARGET_DIR", target_dir)
         .env("RUSTC_WRAPPER", wrapper_exe)
         .env(SRC_DIR_VAR, src_dir_abs)
         .env(JSON_DIR_VAR, json_dir_abs);

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -1,14 +1,5 @@
 use std::process::{Command, Stdio};
 
-// HACK: Clear RUSTFLAGS when running the build/tools on the unsafe code. When
-// running in CI we use `-D warnings`, which then leaks into the build of the
-// unsafe test code causing build errors. This helper clears that flag so that
-// we can allow warnings in the test code.
-fn clear_fixture_rustflags(cmd: &mut Command) -> &mut Command {
-    cmd.env_remove("RUSTFLAGS")
-        .env_remove("CARGO_ENCODED_RUSTFLAGS")
-}
-
 // Verify that `cargo check-unsafe2` works in a clean workspace, specifically
 // that the unsafe checker still reports increased unsafe after a `cargo build`.
 #[test]
@@ -43,8 +34,7 @@ fn run_check_after_cargo_build() {
     );
 
     // Do the initial run of find-unsafe2 to generate the unsafe count JSON.
-    let mut find_cmd = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"));
-    let status = clear_fixture_rustflags(&mut find_cmd)
+    let status = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"))
         .current_dir(&fixture_dir)
         .arg("find-unsafe2")
         .args(["--manifest-path", "example-old/Cargo.toml"])
@@ -55,8 +45,7 @@ fn run_check_after_cargo_build() {
     assert!(status.success(), "cargo-find-unsafe2 failed");
 
     // Run `cargo build` on the workspace before running the unsafe checker.
-    let mut cargo_build_cmd = Command::new("cargo");
-    let status = clear_fixture_rustflags(&mut cargo_build_cmd)
+    let status = Command::new("cargo")
         .current_dir(&fixture_dir)
         .args(["build", "--manifest-path", "example-new/Cargo.toml"])
         .status()
@@ -65,8 +54,7 @@ fn run_check_after_cargo_build() {
 
     // Run `cargo check-unsafe2` after building the workspace to confirm that it
     // still reports increased unsafe ops.
-    let mut check_cmd = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"));
-    let output = clear_fixture_rustflags(&mut check_cmd)
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"))
         .current_dir(&fixture_dir)
         .arg("check-unsafe2")
         .args(["--manifest-path", "example-new/Cargo.toml"])

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -10,10 +10,13 @@ fn run_check_after_cargo_build() {
     // these binaries to test the Cargo subcommands, but Cargo doesn't expose a way
     // for us to list those binaries as a dependency of this crate, so they won't
     // automatically be built if they don't exist.
-    let status = Command::new("cargo")
-        .current_dir(&fixture_dir)
+    let mut build_cmd = Command::new("cargo");
+    build_cmd.current_dir(&fixture_dir).arg("build");
+    if !cfg!(debug_assertions) {
+        build_cmd.arg("--release");
+    }
+    let status = build_cmd
         .args([
-            "build",
             "-p",
             "find_unsafe2",
             "--bin",

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -1,5 +1,7 @@
 use std::process::{Command, Stdio};
 
+// Verify that `cargo check-unsafe2` works in a clean workspace, specifically
+// that the unsafe checker still reports increased unsafe after a `cargo build`.
 #[test]
 fn run_check_after_cargo_build() {
     let fixture_dir = std::fs::canonicalize(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).unwrap();

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -1,5 +1,14 @@
 use std::process::{Command, Stdio};
 
+// HACK: Clear RUSTFLAGS when running the build/tools on the unsafe code. When
+// running in CI we use `-D warnings`, which then leaks into the build of the
+// unsafe test code causing build errors. This helper clears that flag so that
+// we can allow warnings in the test code.
+fn clear_fixture_rustflags(cmd: &mut Command) -> &mut Command {
+    cmd.env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+}
+
 // Verify that `cargo check-unsafe2` works in a clean workspace, specifically
 // that the unsafe checker still reports increased unsafe after a `cargo build`.
 #[test]
@@ -34,7 +43,8 @@ fn run_check_after_cargo_build() {
     );
 
     // Do the initial run of find-unsafe2 to generate the unsafe count JSON.
-    let status = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"))
+    let mut find_cmd = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"));
+    let status = clear_fixture_rustflags(&mut find_cmd)
         .current_dir(&fixture_dir)
         .arg("find-unsafe2")
         .args(["--manifest-path", "example-old/Cargo.toml"])
@@ -45,7 +55,8 @@ fn run_check_after_cargo_build() {
     assert!(status.success(), "cargo-find-unsafe2 failed");
 
     // Run `cargo build` on the workspace before running the unsafe checker.
-    let status = Command::new("cargo")
+    let mut cargo_build_cmd = Command::new("cargo");
+    let status = clear_fixture_rustflags(&mut cargo_build_cmd)
         .current_dir(&fixture_dir)
         .args(["build", "--manifest-path", "example-new/Cargo.toml"])
         .status()
@@ -54,7 +65,8 @@ fn run_check_after_cargo_build() {
 
     // Run `cargo check-unsafe2` after building the workspace to confirm that it
     // still reports increased unsafe ops.
-    let output = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"))
+    let mut check_cmd = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"));
+    let output = clear_fixture_rustflags(&mut check_cmd)
         .current_dir(&fixture_dir)
         .arg("check-unsafe2")
         .args(["--manifest-path", "example-new/Cargo.toml"])

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -1,13 +1,15 @@
-use std::path::Path;
 use std::process::{Command, Stdio};
 
-// HACK: Manually build the find_unsafe2 and check_unsafe2 binaries. We need
-// these binaries to test the Cargo subcommands, but Cargo doesn't expose a way
-// for us to list those binaries as a dependency of this crate, so they won't
-// automatically be built if they don't exist.
-fn build_wrappers(fixture_dir: &Path) {
+#[test]
+fn run_check_after_cargo_build() {
+    let fixture_dir = std::fs::canonicalize(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).unwrap();
+
+    // HACK: Manually build the find_unsafe2 and check_unsafe2 binaries. We need
+    // these binaries to test the Cargo subcommands, but Cargo doesn't expose a way
+    // for us to list those binaries as a dependency of this crate, so they won't
+    // automatically be built if they don't exist.
     let status = Command::new("cargo")
-        .current_dir(fixture_dir)
+        .current_dir(&fixture_dir)
         .args([
             "build",
             "-p",
@@ -20,19 +22,13 @@ fn build_wrappers(fixture_dir: &Path) {
         .status()
         .unwrap();
     assert!(status.success(), "failed to build wrapper binaries");
-}
-
-#[test]
-fn run_check_after_cargo_build() {
-    let fixture_dir = std::fs::canonicalize(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).unwrap();
-
-    build_wrappers(&fixture_dir);
 
     let json_dir = format!(
         "{}/run_check_after_cargo_build",
         env!("CARGO_TARGET_TMPDIR")
     );
 
+    // Do the initial run of find-unsafe2 to generate the unsafe count JSON.
     let status = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"))
         .current_dir(&fixture_dir)
         .arg("find-unsafe2")
@@ -43,6 +39,7 @@ fn run_check_after_cargo_build() {
         .unwrap();
     assert!(status.success(), "cargo-find-unsafe2 failed");
 
+    // Run `cargo build` on the workspace before running the unsafe checker.
     let status = Command::new("cargo")
         .current_dir(&fixture_dir)
         .args(["build", "--manifest-path", "example-new/Cargo.toml"])
@@ -50,6 +47,8 @@ fn run_check_after_cargo_build() {
         .unwrap();
     assert!(status.success(), "cargo build failed");
 
+    // Run `cargo check-unsafe2` after building the workspace to confirm that it
+    // still reports increased unsafe ops.
     let output = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"))
         .current_dir(&fixture_dir)
         .arg("check-unsafe2")

--- a/tools/find_unsafe2/cargo_subcommands/tests/example.rs
+++ b/tools/find_unsafe2/cargo_subcommands/tests/example.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+// HACK: Manually build the find_unsafe2 and check_unsafe2 binaries. We need
+// these binaries to test the Cargo subcommands, but Cargo doesn't expose a way
+// for us to list those binaries as a dependency of this crate, so they won't
+// automatically be built if they don't exist.
+fn build_wrappers(fixture_dir: &Path) {
+    let status = Command::new("cargo")
+        .current_dir(fixture_dir)
+        .args([
+            "build",
+            "-p",
+            "find_unsafe2",
+            "--bin",
+            "find_unsafe2",
+            "--bin",
+            "check_unsafe2",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to build wrapper binaries");
+}
+
+#[test]
+fn run_check_after_cargo_build() {
+    let fixture_dir = std::fs::canonicalize(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).unwrap();
+
+    build_wrappers(&fixture_dir);
+
+    let json_dir = format!(
+        "{}/run_check_after_cargo_build",
+        env!("CARGO_TARGET_TMPDIR")
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_cargo-find-unsafe2"))
+        .current_dir(&fixture_dir)
+        .arg("find-unsafe2")
+        .args(["--manifest-path", "example-old/Cargo.toml"])
+        .env("FIND_UNSAFE2_SRC_DIR", &fixture_dir)
+        .env("FIND_UNSAFE2_JSON_DIR", &json_dir)
+        .status()
+        .unwrap();
+    assert!(status.success(), "cargo-find-unsafe2 failed");
+
+    let status = Command::new("cargo")
+        .current_dir(&fixture_dir)
+        .args(["build", "--manifest-path", "example-new/Cargo.toml"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "cargo build failed");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cargo-check-unsafe2"))
+        .current_dir(&fixture_dir)
+        .arg("check-unsafe2")
+        .args(["--manifest-path", "example-new/Cargo.toml"])
+        .env("FIND_UNSAFE2_JSON_DIR", &json_dir)
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "cargo-check-unsafe2 succeeded unexpectedly"
+    );
+}

--- a/tools/find_unsafe2/example-new/src/lib.rs
+++ b/tools/find_unsafe2/example-new/src/lib.rs
@@ -41,12 +41,12 @@ fn f6(r: &i32) -> i32 {
 
 unsafe fn f7a(x: usize) -> i32 {
     // Error: integer-to-pointer casts are forbidden.
-    *(x as *const i32)
+    unsafe { *(x as *const i32) }
 }
 
 unsafe fn f7b(x: &i32) -> i32 {
     // No error; reference-to-pointer casts are allowed.
-    *(x as *const i32)
+    unsafe { *(x as *const i32) }
 }
 
 

--- a/tools/find_unsafe2/example-old/src/lib.rs
+++ b/tools/find_unsafe2/example-old/src/lib.rs
@@ -44,11 +44,11 @@ fn f6(r: &i32) -> i32 {
 }
 
 unsafe fn f7a(x: *const i32) -> i32 {
-    *x
+    unsafe { *x }
 }
 
 unsafe fn f7b(x: *const i32) -> i32 {
-    *x
+    unsafe { *x }
 }
 
 


### PR DESCRIPTION
> NOTE: I am still testing this, but I'm putting the code up early for visiblity/discussion.

The check-unsafe2 Cargo command works by running `cargo build` with `RUSTC_WRAPPER` set to the `check_unsafe2` binary. This means that if the project was already built before running `check-unsafe2`, `cargo build` will be a no-op and don't perform the unsafe count. This then results in failed edits in the CRISP loop when check-unsafe2 fails to report increased unsafe counts to the agent.

~This PR attempts to fix this by automatically running `cargo clean` before `cargo build`, ensuring that Cargo will actually build the project. There's a problem with this solution, though: If the agent runs `cargo build` and `cargo check-unsafe2` at the same time, then we can potentially rebuild the project between the `cargo clean` and `cargo build` steps done by check-unsafe2, causing the same bug to still happen. To work around that, I've added a note to the agent prompt that tells it to not run any other Cargo commands at the same time as `cargo check-unsafe2`. That doesn't feel like a good solution to me, but I don't know if there's a good way for us to get Cargo to always re-run even when the workspace is clean.~

This PR fixes this by using a fresh `target` dir for the `cargo build` command run by `cargo check-unsafe2`. This ensures a full build every time and prevents any concurrent `cargo build` operations in the workspace from interfering with the unsafe checker.