### PR TITLE
Split agent planning into a separate step

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd /root/project
 export CRISP_API_BASE=https://api.openai.com/v1
 export CRISP_API_KEY=sk-your-api-key-here
 
-# Optional: override the `models.agent`, `models.rewriter`, etc. selections
+# Optional: override the `models.agent_plan`, `models.agent_loop`, `models.rewriter`, etc. selections
 # in crisp.toml for this run.
 #export CRISP_API_MODEL=gpt-5.6-sol
 

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -371,7 +371,12 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
     best_unsafe_count = None
     consecutive_failures = 0
-    n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
+    n_plans = prior_agent_plans(mvir, n_code)
+    if not n_plans:
+        if 'agent' in args.llm_mode:
+            n_plans = w.do_safety_plan_agent(n_code, n_c_code)[1]
+        else:
+            n_plans = TreeNode.new(mvir, files={})
 
     target_goal = None
     target_goal_tries = 0

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -24,7 +24,8 @@ def _snapshot_to_family_alias(model: str) -> str:
     m = _SNAPSHOT_SUFFIX.match(model)
     return m.group("alias") if m else model
 
-def _codex_command(cfg: Config, subcmd: str, args: list[str], codex_login: bool = False) -> list[str]:
+def _codex_command(cfg: Config, subcmd: str, args: list[str],
+                   model: str, codex_login: bool = False) -> list[str]:
     cmd = ['codex', subcmd]
 
     if codex_login:
@@ -32,7 +33,7 @@ def _codex_command(cfg: Config, subcmd: str, args: list[str], codex_login: bool 
         # override the model; everything else uses codex's defaults.
         # The --model flag does not support snapshot-style model identifiers so
         # we attempt to convert snapshots to model family aliases.
-        model = _snapshot_to_family_alias(llm.API_MODEL or cfg.models.agent)
+        model = _snapshot_to_family_alias(llm.API_MODEL or model)
         cmd += ['--model', model]
     else:
         config_settings = {
@@ -41,7 +42,7 @@ def _codex_command(cfg: Config, subcmd: str, args: list[str], codex_login: bool 
             #'model_providers.crisp.api_key': llm.API_KEY or 'sk-no-api-key',
             'model_providers.crisp.env_key': 'CRISP_API_KEY',
             'model_provider': 'crisp',
-            'model': llm.API_MODEL or cfg.models.agent,
+            'model': llm.API_MODEL or model,
             # TODO: OpenAI pricing is based on input and output tokens, with 
             # long context tokens costing twice as much as short context ones.
             # We might want to set limits to avoid the long context pricing.
@@ -98,6 +99,7 @@ def run_rewrite(
     cfg: Config,
     mvir: MVIR,
     prompt: str,
+    model: str,
     input_code: TreeNode,
     extra_code: TreeNode | list[TreeNode] = [],
     planning_files: TreeNode | None = None,
@@ -168,7 +170,7 @@ def run_rewrite(
                 '--dangerously-bypass-approvals-and-sandbox',
                 '--skip-git-repo-check',
                 prompt,
-            ], codex_login=codex_login)
+            ], codex_login=codex_login, model=model)
             print(codex_cmd)
             all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 

--- a/crisp/config.py
+++ b/crisp/config.py
@@ -40,7 +40,8 @@ class ConfigBase:
 
 @dataclass(frozen = True)
 class ModelsConfig(ConfigBase):
-    agent: str  = "gpt-5.6-terra"
+    agent_plan: str = "gpt-5.6-sol"
+    agent_loop: str = "gpt-5.6-terra"
     postprocess: str = "gpt-5.6-luna"
     # `rewriter = None` means call `/v1/models` and pick the first from the list.
     rewriter: str | None = None

--- a/crisp/git.py
+++ b/crisp/git.py
@@ -37,6 +37,7 @@ OP_NODE_KINDS = {
 }
 
 HISTORY_INDEX_KEYS = set((kind, new) for (kind, (old, new)) in OP_NODE_KINDS.items())
+HISTORY_INDEX_OLD_KEYS = set((kind, old) for (kind, (old, new)) in OP_NODE_KINDS.items())
 
 def render(mvir: MVIR, target: TreeNode) -> pygit2.Oid:
     """
@@ -49,7 +50,19 @@ def render(mvir: MVIR, target: TreeNode) -> pygit2.Oid:
         # Try to find an op that produced the last tree.
         tree = trees[-1]
         op_node_id = None
-        for ie in mvir.index(tree.node_id()):
+        index = mvir.index(tree.node_id())
+
+        # Save a set of all nodes with `old_code`
+        old_node_ids = set()
+        for ie in index:
+            if (ie.kind, ie.key) in HISTORY_INDEX_OLD_KEYS:
+                old_node_ids.add(ie.node_id)
+
+        for ie in index:
+            if ie.node_id in old_node_ids:
+                # Ignore nodes where `old_code==new_code`,
+                # such as the planning node from agent mode
+                continue
             if (ie.kind, ie.key) in HISTORY_INDEX_KEYS:
                 op_node_id = ie.node_id
                 break

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1310,6 +1310,13 @@ class Workflow:
             self.find_unsafe2_json(n_code),
         ]
         if n_test_code is not None:
+            # In planning mode, we do provide the entire C code to the planner
+            # since that might increase the quality of the plan. However, if
+            # we later run the safety loop in `agent_sim_no_tests` mode the
+            # safety agent will not have access to the C code, and the plan
+            # might contain references to it. This might confuse the agent and
+            # break the `agent_sim_no_tests` mode.
+            # TODO: un-break that mode somehow (without hiding the C code).
             extra_code.append(n_test_code)
 
         prompt = AGENT_PLAN_PROMPT.format(

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1197,7 +1197,7 @@ class Workflow:
         )
         if prompt_suffix is not None:
             prompt = f'{prompt}\n\n{prompt_suffix}'
-        return agent.run_rewrite(cfg, mvir, prompt, n_code,
+        return agent.run_rewrite(cfg, mvir, prompt, self.cfg.models.agent_loop, n_code,
             extra_code = extra_code,
             planning_files = n_plans,
             codex_login=self.codex_login,
@@ -1316,7 +1316,7 @@ class Workflow:
             cargo_dir_path = cargo_dir,
             after_refactoring_instruction = after_refactoring_instruction,
         )
-        return agent.run_rewrite(cfg, mvir, prompt, n_code,
+        return agent.run_rewrite(cfg, mvir, prompt, self.cfg.models.agent_plan, n_code,
             extra_code = extra_code,
             planning_files = None,
             codex_login=self.codex_login,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -118,21 +118,9 @@ New signatures:
 {input_files}
 '''
 
-AGENT_SAFETY_PROMPT = '''
-Please refactor the Rust code in `{cargo_dir_path}` to be safe, without changing its behavior.  The goal is to make the code fully safe, including migrating to safe memory management (`Box`/`Vec`/`Rc`) and  safe pointer types (`&T`/`&[T]`) throughout.
-
-{target_goal}
-
-You are executing one iteration of a loop that will be re-invoked on the same codebase until the unsafe count reaches zero or progress stalls. To carry state between iterations, maintain a planning file at `SAFETY_PLAN.md`:
-
-- **First, check whether `SAFETY_PLAN.md` already exists.** If it does, read it in full. It is your own notes from prior iterations.
-- If the existing `SAFETY_PLAN.md` applies to your current target, Use it to pick up where the previous run left off rather than starting over.
-- If `SAFETY_PLAN.md` does not exist, or if it exists but applies to an unrelated target, make a new plan for addressing the current target. Examine the target along with any callers/callees, use sites, and other related logic to understand the functionality it provides. Think about how to implement the same functionality using only safe Rust constructs. Then, plan out step by step how to migrate from the unsafe version to the safe equivalent. This plan may be as small as a single step if the target is simple, or it may be many steps if the target is complex or has many interactions. Once you have a plan, write it to `SAFETY_PLAN.md`.
-- **Before you finish, update `SAFETY_PLAN.md`** to reflect what you actually did this iteration, what is now complete, what remains, and any pitfalls or dead ends future iterations should avoid. Keep it concise — it is a working scratchpad, not a report.
-- When rewriting the plan due to switching targets, pay close attention to any relevant pitfalls or dead ends recorded in the previous plan such that future iterations do not repeat the same mistakes. This is also a good time to trim and clean up the plan so it only contains the next steps and relevant notes.
-- If a planned unit turns out to be too complex or blocked by prerequisite work, update `SAFETY_PLAN.md` to record the blocker, split the work into smaller steps, and switch to the prerequisite or smaller step. Prefer steps that directly reduce the unsafe count, but preliminary safe refactors are acceptable when they are necessary to remove unsafe code in a later iteration.
-
-Then carry out the next step of the plan.
+AGENT_PLAN_PROMPT = '''
+Make a plan to refactor the Rust code in `{cargo_dir_path}` to be safe, without changing its behavior.  The goal is to make the code fully safe, including migrating to safe memory management (`Box`/`Vec`/`Rc`) and  safe pointer types (`&T`/`&[T]`) throughout.
+Write the plan to a file named `SAFETY_PLAN.md`.
 
 The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions.
 
@@ -142,10 +130,25 @@ Implementation code may be freely refactored to improve safety. Here are some ex
 - Eliminate calls to FFI imports and other unsafe functions. Try to replace these with suitable safe Rust operations, e.g. `printf` -> `println!`.
 - Remove the `unsafe` qualifier from functions that no longer need it, so that their callers can be made safe.
 
-For FFI entry points, the following rules apply:
+For FFI entry points, the following rules apply (these rules must be copied verbatim into the plan and never changed or broken):
 - You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
 - For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
 - Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
+
+{after_refactoring_instruction}
+
+Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:
+```sh
+cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
+```
+This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
+'''
+
+AGENT_SAFETY_PROMPT = '''
+Continue the plan from `SAFETY_PLAN.md`.
+**Before you finish, update `SAFETY_PLAN.md`** to reflect what you actually did this iteration, what is now complete, what remains, and any pitfalls or dead ends future iterations should avoid. Keep it concise — it is a working scratchpad, not a report.
+
+{target_goal}
 
 {after_refactoring_instruction}
 
@@ -1288,6 +1291,41 @@ class Workflow:
             n_new_code = self.llm_safety(n_code)
 
         return self.do_validate_and_repair(n_code, n_new_code, n_test_code)
+
+    @step
+    def do_safety_plan_agent(
+        self,
+        n_code: TreeNode,
+        n_test_code: TreeNode,
+    ) -> tuple[TreeNode | None, TreeNode | None]:
+        cfg, mvir = self.cfg, self.mvir
+        cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
+
+        if cfg.test_command is not None:
+            after_refactoring_instruction = AGENT_AFTER_REFACTORING_RUN_TESTS \
+                    .format(test_cmd = cfg.test_command)
+        else:
+            after_refactoring_instruction = AGENT_AFTER_REFACTORING_BUILD
+
+        extra_code = [
+            self.find_unsafe2_json(n_code),
+        ]
+        if n_test_code is not None:
+            extra_code.append(n_test_code)
+
+        prompt = AGENT_PLAN_PROMPT.format(
+            cargo_dir_path = cargo_dir,
+            after_refactoring_instruction = after_refactoring_instruction,
+        )
+        return agent.run_rewrite(cfg, mvir, prompt, n_code,
+            extra_code = extra_code,
+            planning_files = None,
+            codex_login=self.codex_login,
+            clean_cmds = [
+                ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
+            ],
+            find_unsafe2_json_dir = analysis.UNSAFE_JSON_DIR,
+        )
 
     @step
     def do_safety_step_agent(

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -178,10 +178,6 @@ AGENT_TARGET_GOAL_FUNCTION = '''
 Your current target is the `{func_name}` function, along with any similar or closely related functions.  Your goal is to change the function in question to use only safe types (such as `Box`, `Vec`, or `Rc`) internally and in its signature, and to replace any unsafe FFI calls (e.g. `libc::printf`) with safe equivalents.  You should aim to make callees of the target function safe if it's feasible to do so, that way the entire call tree is safe.
 '''.strip()
 
-AGENT_TARGET_GOAL_OTHER = '''
-You currently have no specific target.  Scan the codebase for any remaining unsafe types, operations, or definitions (excluding FFI entry points) and identify a single reasonably-scoped unit of code (such as a file/module, a data structure and its related functions, or even a set of related struct fields) that uses `unsafe` for you to work on.
-'''.strip()
-
 class AgentTarget:
     def prompt(self):
         return self.PROMPT_FMT.format(**dataclasses.asdict(self))
@@ -208,7 +204,10 @@ class AgentTargetOther(AgentTarget):
     """
     Remove any leftover unsafe from the codebase.
     """
-    PROMPT_FMT = AGENT_TARGET_GOAL_OTHER
+    # The prompt asks the agent to continue the plan, so we
+    # expect it to make a reasonable choice for the next target
+    # based on that document.
+    PROMPT_FMT = ""
 
 
 _CRISP_DIR = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
Split the planning into a separate part outside of the main safety loop, instead of the old approach of prompting to create a `SAFETY_PLAN.md` file if it doesn't already exist.