### PR TITLE
Check the ignore_spec before the file type

### DIFF
--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -83,6 +83,8 @@ class WorkContainer:
         dest_prefix = os.path.dirname(rel_path)
         with tarfile.open(fileobj=tar_io, mode='r') as t:
             while (info := t.next()) is not None:
+                if ignore_spec is not None and ignore_spec.match_file(info.name):
+                    continue
                 match info.type:
                     case tarfile.REGTYPE:
                         pass
@@ -93,8 +95,6 @@ class WorkContainer:
                         continue
                     case t:
                         raise ValueError(f"expected REGTYPE, LNKTYPE or DIRTYPE, but got {t} for file {info.name}")
-                if ignore_spec is not None and ignore_spec.match_file(info.name):
-                    continue
                 f = t.extractfile(info)
                 dest_path = os.path.normpath(os.path.join(dest_prefix, info.name))
                 assert dest_path not in files, 'duplicate entry for %s' % dest_path

--- a/crisp/sandbox/sudo.py
+++ b/crisp/sandbox/sudo.py
@@ -83,6 +83,8 @@ class SudoSandbox:
         files = {}
         with tarfile.open(fileobj=tar_io, mode='r') as t:
             while (info := t.next()) is not None:
+                if ignore_spec is not None and ignore_spec.match_file(info.name):
+                    continue
                 match info.type:
                     case tarfile.REGTYPE:
                         pass
@@ -93,8 +95,6 @@ class SudoSandbox:
                         continue
                     case t:
                         raise ValueError(f"expected REGTYPE, LNKTYPE or DIRTYPE, but got {t} for file {info.name}")
-                if ignore_spec is not None and ignore_spec.match_file(info.name):
-                    continue
                 f = t.extractfile(info)
                 # Prefix output paths with the requested `rel_path`.
                 dest_path = os.path.normpath(os.path.join(rel_path, info.name))


### PR DESCRIPTION
Fix an ordering issue: if the sandbox contains a file of an unknown type (e.g. a symlink) that's also on the ignore list, check the list first and discard the file. Otherwise the commit step errors out on that file.