### PR TITLE
Misc fixes for P02

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM docker.io/rust:trixie AS tractor-crisp-user
 
 # rust-analyzer 0.0.329 (used by tools/*) requires Rust 1.93 at minimum
 # find_unsafe2 requires a specific nightly and rustc-internal components
-RUN rustup default nightly-2026-05-11
-RUN rustup +nightly-2026-05-11 component add rustfmt rustc-dev rust-src llvm-tools
+RUN rustup default nightly-2026-06-17
+RUN rustup +nightly-2026-06-17 component add rustfmt rustc-dev rust-src llvm-tools
 
 RUN apt-get update
 

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -521,6 +521,11 @@ class PickTarget:
 
     def current_target_goal(self, w, n_code):
         # Keep going with the current goal if possible.
+
+        # Optimistically take fuel from both the target and file to continue
+        # with the current goal.  If the target is out of fuel, we change
+        # targets and `give()` the target more fuel below; if the file is out
+        # of fuel, we changes files and targets and `give()` both more fuel.
         target_had_fuel = self.fuel_target.try_use()
         file_had_fuel = self.fuel_file.try_use()
 
@@ -565,8 +570,13 @@ class PickTarget:
         # Found no goal in any file, but `count_unsafe2` still reported some
         # unsafe code.  Tell the agent to check the entire codebase for
         # leftover unsafety.
+        self.target_goal = AgentTargetOther()
+        self.fuel_file.give()
+        self.fuel_file.use()
+        self.fuel_target.give()
+        self.fuel_target.use()
         print('PickTarget: no valid targets')
-        return AgentTargetOther()
+        return self.target_goal
 
 
 def pick_file_and_list_targets(w, n_code):

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import ast
+from collections import defaultdict
 from dataclasses import dataclass
 import glob
 import json
@@ -27,7 +28,7 @@ from .mvir import MVIR, NodeId, FileNode, TreeNode, LlmOpNode, \
 from .sandbox import run_sandbox
 from .work_dir import lock_work_dir, set_keep_work_dir
 from .workflow import (
-    Workflow, OutOfFuelError, AgentTargetField, AgentTargetFunction,
+    Workflow, FuelCounter, OutOfFuelError, AgentTargetField, AgentTargetFunction,
     AgentTargetOther,
 )
 
@@ -322,6 +323,10 @@ class FuelLimits:
     # the outer loop will pick a new target immediately instead.
     safety_tries_per_target: int
 
+    # Give the agent this many iterations within each file before swiching to a
+    # new file.
+    safety_tries_per_file: int
+
 def total_code_size(mvir, n_code):
     total = 0
     for name, file in n_code.files.items():
@@ -341,6 +346,7 @@ def get_fuel_limits(mvir, n_code):
             safety_tries = 8,
             max_consecutive_failures = 3,
             safety_tries_per_target = 2,
+            safety_tries_per_file = 10,
         )
     elif size < 20000:
         # P01
@@ -348,6 +354,7 @@ def get_fuel_limits(mvir, n_code):
             safety_tries = 45,
             max_consecutive_failures = 5,
             safety_tries_per_target = 3,
+            safety_tries_per_file = 20,
         )
     else:
         # P02 - run forever
@@ -355,6 +362,7 @@ def get_fuel_limits(mvir, n_code):
             safety_tries = 9999,
             max_consecutive_failures = 9999,
             safety_tries_per_target = 5,
+            safety_tries_per_file = 50,
         )
     print(f'code size = {size}')
     print(f'default limits = {defaults!r}')
@@ -369,6 +377,9 @@ def get_fuel_limits(mvir, n_code):
         safety_tries_per_target = int(
             os.environ.get('LLM_SAFETY_TRIES_PER_TARGET',
                 defaults.safety_tries_per_target)),
+        safety_tries_per_file = int(
+            os.environ.get('LLM_SAFETY_TRIES_PER_FILE',
+                defaults.safety_tries_per_file)),
     )
 
 def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
@@ -386,8 +397,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
         else:
             n_plans = TreeNode.new(mvir, files={})
 
-    target_goal = None
-    target_goal_tries = 0
+    pick_target = PickTarget(limits)
 
     prev_fuel = None
     while True:
@@ -456,13 +466,7 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                         prompt_suffix = suffix)
 
                 case 'agent_rand_target':
-                    if (target_goal is None or target_goal_tries == 0
-                            or target_goal_is_done(w, n_code, target_goal)):
-                        target_goal = pick_target_goal(w, n_code)
-                        target_goal_tries = limits.safety_tries_per_target
-
-                    target_goal_tries -= 1
-
+                    target_goal = pick_target.current_target_goal(w, n_code)
                     n_new_code, n_new_plans = w.do_safety_step_agent(
                         n_code, n_c_code, n_plans,
                         target_goal = target_goal)
@@ -504,15 +508,80 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     print('final unsafe count = %d' % unsafe_count)
     print('final test exit code = %d' % n_op_test.exit_code)
 
-def pick_target_goal(w, n_code):
+
+class PickTarget:
+    def __init__(self, limits):
+        self.fuel_file = FuelCounter('target file',
+            default_give=limits.safety_tries_per_file)
+        self.fuel_target = FuelCounter('target goal',
+            default_give=limits.safety_tries_per_target)
+        self.file_target_goals = []
+        self.current_file = None
+        self.target_goal = None
+
+    def current_target_goal(self, w, n_code):
+        # Keep going with the current goal if possible.
+        target_had_fuel = self.fuel_target.try_use()
+        file_had_fuel = self.fuel_file.try_use()
+
+        if (
+            file_had_fuel and target_had_fuel
+            and self.target_goal is not None
+            and not target_goal_is_done(w, n_code, self.target_goal)
+        ):
+            print(f'PickTarget: continue with {self.target_goal} from {self.current_file}')
+            print(f'  target fuel: {self.fuel_target.fuel}')
+            print(f'  file fuel: {self.fuel_file.fuel}')
+            return self.target_goal
+
+        # Try to pick a goal from the current file if there's fuel left for it.
+        if file_had_fuel:
+            while len(self.file_target_goals) > 0:
+                candidate_goal = self.file_target_goals.pop()
+                if not target_goal_is_done(w, n_code, candidate_goal):
+                    self.target_goal = candidate_goal
+                    self.fuel_target.give()
+                    self.fuel_target.use()
+                    print(f'PickTarget: new target {self.target_goal} from {self.current_file}')
+                    print(f'  target fuel: {self.fuel_target.fuel}')
+                    print(f'  file fuel: {self.fuel_file.fuel}')
+                    return self.target_goal
+
+        # Switch files, and build a new list of targets.
+        self.current_file, self.file_target_goals = pick_file_and_list_targets(w, n_code)
+        if len(self.file_target_goals) > 0:
+            # No need to check `target_goal_is_done`, since none of the goals
+            # in the list have been fixed yet.
+            self.target_goal = self.file_target_goals.pop()
+            self.fuel_file.give()
+            self.fuel_file.use()
+            self.fuel_target.give()
+            self.fuel_target.use()
+            print(f'PickTarget: new file {self.current_file}, target {self.target_goal}')
+            print(f'  target fuel: {self.fuel_target.fuel}')
+            print(f'  file fuel: {self.fuel_file.fuel}')
+            return self.target_goal
+
+        # Found no goal in any file, but `count_unsafe2` still reported some
+        # unsafe code.  Tell the agent to check the entire codebase for
+        # leftover unsafety.
+        print('PickTarget: no valid targets')
+        return AgentTargetOther()
+
+
+def pick_file_and_list_targets(w, n_code):
     # Choose a `target_goal`.
-    function_targets = []
-    field_targets = []
+    @dataclass(frozen = True)
+    class FileTargets:
+        functions: list
+        fields: list
+    files = defaultdict(lambda: FileTargets([], []))
     for n_json_file in w.find_unsafe2_json_files(n_code):
         j = n_json_file.body_json()
-        function_targets.extend(AgentTargetFunction(k)
-            for k,v in j['fns'].items()
-            if v['total_unsafe'] > 0 and not v['is_ffi_entry_point'])
+        for fn_name, j_fn in j['fns'].items():
+            if j_fn['total_unsafe'] == 0 or j_fn['is_ffi_entry_point']:
+                continue
+            files[j_fn['filename']].functions.append(AgentTargetFunction(fn_name))
         for type_name, j_type in j['types'].items():
             if 'type' in j_type['field_contains_raw_ptr']:
                 # This is a type alias, not a struct
@@ -521,27 +590,55 @@ def pick_target_goal(w, n_code):
                 # we would end up telling the agent to fix the
                 # "type" field of a non-struct.)
                 continue
-            field_targets.extend(AgentTargetField(type_name, k)
+            files[j_type['filename']].fields.extend(AgentTargetField(type_name, k)
                 for k,v in j_type['field_contains_raw_ptr'].items()
                 if v > 0)
 
-    # Prefer fields over functions by giving them 5x normal
-    # weight.
-    functions_weight = len(function_targets)
-    fields_weight = 5 * len(field_targets)
-    target_lists = [function_targets, field_targets]
-    weights = [functions_weight, fields_weight]
-    if sum(weights) > 0:
-        print(f'choosing target with category weights {weights!r}')
-        target_list, = random.choices(target_lists, weights)
-        target_goal = random.choice(target_list)
-    else:
-        # We found no fields or functions, but `count_unsafe2`
-        # still reported some unsafe code.  Tell the agent to
-        # check the entire codebase for leftover unsafety.
-        target_goal = AgentTargetOther()
+    # Exclude any files that are already fully safe.
+    files = {k: v for k,v in files.items() if len(v.functions) + len(v.fields) > 0}
 
-    return target_goal
+    if len(files) == 0:
+        # We found no unsafe fields or functions.
+        return None, []
+
+    print(f'pick_file_and_list_targets: picking from {len(files)} files')
+    filename, file_targets = random.choice(list(files.items()))
+    functions = file_targets.functions
+    fields = file_targets.fields
+    print(f'  picked file {filename} with {len(functions)} function targets '
+        f'and {len(fields)} field targets')
+
+    # We have a limited per-file budget, and we prefer to spend it on fields
+    # rather than functions, so we try to put fields earlier in the final list.
+    order = []
+
+    # Shuffle functions and fields so each one has equal priority within its
+    # category.
+    random.shuffle(functions)
+    random.shuffle(fields)
+
+    while len(functions) > 0 and len(fields) > 0:
+        # Prefer fields over functions by giving them 5x normal weight.
+        functions_weight = len(functions)
+        fields_weight = 5 * len(fields)
+        total_weight = functions_weight + fields_weight
+        x = random.randrange(total_weight)
+        if x < functions_weight:
+            order.append(functions.pop())
+        else:
+            order.append(fields.pop())
+
+    order.extend(fields)
+    order.extend(functions)
+
+    # `PickTarget` actually processes the list in reverse order, so reverse it
+    # to put higher-priority items near the end.
+    order.reverse()
+
+    print(f'  order ({len(order)} items):')
+    for x in order:
+        print(f'    {x}')
+    return filename, order
 
 def target_goal_is_done(w, n_code, target_goal):
     total = 0

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -217,7 +217,12 @@ _CRISP_DIR = os.path.dirname(os.path.dirname(__file__))
 @dataclass
 class FuelCounter:
     desc: str
+    default_give: int | None = None
     fuel: int = 0
+
+    def __post_init__(self):
+        if self.default_give is not None:
+            self.give()
 
     def use(self):
         if self.fuel == 0:
@@ -225,7 +230,21 @@ class FuelCounter:
         else:
             self.fuel -= 1
 
-    def give(self, amount):
+    def try_use(self) -> bool:
+        if self.fuel == 0:
+            return False
+        else:
+            self.fuel -= 1
+            return True
+
+    def is_empty(self) -> bool:
+        return self.fuel == 0
+
+    def give(self, amount: int | None = None):
+        if amount is None:
+            amount = self.default_give
+        if amount is None:
+            raise ValueError('must provide `amount` because `default_give` is None')
         if amount > self.fuel:
             self.fuel = amount
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -134,6 +134,7 @@ For FFI entry points, the following rules apply (these rules must be copied verb
 - You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
 - For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
 - Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
+- Don't add calls to FFI entry points (`*_ffi` functions).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
 
 {after_refactoring_instruction}
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1091,8 +1091,8 @@ class Workflow:
                     sb.join(rust_path_rel, 'Cargo.toml')])
 
                 # `cargo fmt` sometimes fails with an internal error about
-                # being unable to remove trailing whitespace.  We log the error
-                # in that case and then suppress it.
+                # being unable to remove trailing whitespace (see issue #146).
+                # We log the error in that case and then suppress it.
                 if exit_code != 0:
                     logs2 += f'\n`cargo fmt` failed with code {exit_code}\n'.encode()
                     exit_code = 0

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -843,8 +843,12 @@ class Workflow:
                 file = mvir.node(file_id)
                 old_src = file.body_str()
                 new_src = (old_src
+                    # This handles both `from_exposed_addr` and `from_exposed_addr_mut`
                     .replace('ptr::from_exposed_addr', 'ptr::with_exposed_provenance')
-                    .replace('.expose_addr()', '.expose_provenance()'))
+                    .replace('.expose_addr()', '.expose_provenance()')
+                    # `raw_ref_op` no longer requires a feature gate
+                    .replace('#![feature(raw_ref_op)]', '')
+                    )
                 new_file = FileNode.new(mvir, new_src)
                 new_file_id = new_file.node_id()
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -164,6 +164,7 @@ After refactoring, make sure the code still passes the tests.  Run the tests usi
 ```sh
 {test_cmd}
 ```
+Note: you MUST NOT edit the tests (or the original C code) to get them to pass.  Instead, you must ensure that your edits to the codebase preserve ALL externally-visible behavior that's exercised by the tests.
 '''.strip()
 
 AGENT_AFTER_REFACTORING_BUILD = '''

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -1001,6 +1001,14 @@ class Workflow:
                 exit_code, logs2 = sb.run([
                     'cargo', 'fmt', '--manifest-path',
                     sb.join(rust_path_rel, 'Cargo.toml')])
+
+                # `cargo fmt` sometimes fails with an internal error about
+                # being unable to remove trailing whitespace.  We log the error
+                # in that case and then suppress it.
+                if exit_code != 0:
+                    logs2 += f'\n`cargo fmt` failed with code {exit_code}\n'.encode()
+                    exit_code = 0
+
                 logs = b'\n\n'.join((logs, logs2))
 
             if exit_code == 0:

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -429,6 +429,10 @@ class Workflow:
 
         code = self.patch_cargo_toml_workspace(code)
 
+        # Note: the toolchain upgrade must run after c2rust-refactor, since
+        # that tool only supports an older version of Rust.
+        code = self.patch_upgrade_toolchain(code)
+
         if not self.cargo_check_json_op(code).passed:
             print('error: build failed after transpile')
             return None
@@ -788,6 +792,65 @@ class Workflow:
             body = f'patch build.rs (libs = {libs})',
         )
         mvir.set_tag('op_history', n_op.node_id(), n_op.kind + ' patch_build_rs')
+        return n_op
+
+    @step
+    def patch_upgrade_toolchain(self, code: TreeNode) -> TreeNode:
+        """
+        Patch `rust-toolchain.toml` and `.rs` files to make the project build
+        with a newer toolchain.  c2rust-transpile outputs code for a 2023
+        toolchain by default, but find-unsafe2 uses a newer 2026 toolchain;
+        this upgrades the project to work with the latter.
+
+        This is necessary because c2rust-transpile now outputs calls to the
+        strict provenance APIs, which were renamed in 2024, making the
+        transpiler output incompatible with find-unsafe2.  Upgrading to the
+        newer toolchain (and renaming the strict provenance calls in the
+        process) allows find-unsafe2 to work on the transpiled code.
+        """
+        n_op = self.patch_upgrade_toolchain_op(code)
+        new_code = self.mvir.node(n_op.new_code)
+        return new_code
+
+    @step
+    def patch_upgrade_toolchain_op(self, code: TreeNode) -> EditOpNode:
+        cfg, mvir = self.cfg, self.mvir
+
+        new_files = {}
+        for path, file_id in code.files.items():
+            if path.endswith('.rs'):
+                file = mvir.node(file_id)
+                old_src = file.body_str()
+                new_src = (old_src
+                    .replace('ptr::from_exposed_addr', 'ptr::with_exposed_provenance')
+                    .replace('.expose_addr()', '.expose_provenance()'))
+                new_file = FileNode.new(mvir, new_src)
+                new_file_id = new_file.node_id()
+
+            elif path.endswith('rust-toolchain.toml'):
+                file = mvir.node(file_id)
+                OLD_TOOLCHAIN = 'nightly-2023-04-15'
+                NEW_TOOLCHAIN = 'nightly-2026-06-17'
+                old_src = file.body_str()
+                assert OLD_TOOLCHAIN in old_src, f'old toolchain toml = {old_src!r}'
+                new_src = old_src.replace(OLD_TOOLCHAIN, NEW_TOOLCHAIN)
+                new_file = FileNode.new(mvir, new_src)
+                new_file_id = new_file.node_id()
+
+            else:
+                new_file_id = file_id
+
+            new_files[path] = new_file_id
+
+        new_code = TreeNode.new(mvir, files = new_files)
+
+        n_op = EditOpNode.new(
+            mvir,
+            old_code = code.node_id(),
+            new_code = new_code.node_id(),
+            body = f'patch to upgrade toolchain',
+        )
+        mvir.set_tag('op_history', n_op.node_id(), n_op.kind + ' patch_upgrade_toolchain')
         return n_op
 
     @step

--- a/tools/find_unsafe2/src/bin/check_unsafe2.rs
+++ b/tools/find_unsafe2/src/bin/check_unsafe2.rs
@@ -29,6 +29,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
     // new unsafe function that wasn't present before, we detect that as a regression.
     let empty_fn = FunctionOutputs {
         total_unsafe: 0,
+        filename: String::new(),
         is_unsafe_fn: false,
         is_mut_static: false,
         derefs_raw_ptr: 0,
@@ -46,6 +47,7 @@ fn check_outputs(old: &Outputs, new: &Outputs) -> bool {
     }
 
     let empty_type = TypeOutputs {
+        filename: String::new(),
         field_contains_raw_ptr: IndexMap::new(),
     };
     for (type_name, new_type) in types {
@@ -65,6 +67,7 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
     let FunctionOutputs {
         // Don't check the total.  Each element that feeds into this total is checked individually.
         total_unsafe: _,
+        filename: _,
         is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
         ref uses_static_mut, ref uses_union_field, ref uses_foreign_fn,
         casts_int_to_ptr, sig_contains_raw_ptr,
@@ -102,6 +105,7 @@ fn check_function_outputs(name: &str, old: &FunctionOutputs, new: &FunctionOutpu
 
 fn check_type_outputs(name: &str, old: &TypeOutputs, new: &TypeOutputs) -> bool {
     let TypeOutputs {
+        filename: _,
         ref field_contains_raw_ptr,
     } = *new;
     let mut ok = true;

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -12,7 +12,7 @@ use std::ops::ControlFlow;
 use indexmap::IndexMap;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::ty::TyCtxt;
-use rustc_public::{DefId, CrateDef, CrateItem, ItemKind};
+use rustc_public::{DefId, CrateDef, CrateDefType, CrateItem, ItemKind};
 use rustc_public::mir::{
     Body, Terminator, TerminatorKind, Place, Rvalue, Operand, Safety, FieldIdx, ProjectionElem,
     AggregateKind,

--- a/tools/find_unsafe2/src/lib.rs
+++ b/tools/find_unsafe2/src/lib.rs
@@ -179,6 +179,8 @@ pub struct Outputs {
 pub struct FunctionOutputs {
     /// Sum of all unsafe counts for this function.
     pub total_unsafe: usize,
+    /// Name of the file that contains this function.
+    pub filename: String,
 
     /// Unsafety: the function itself is unsafe.
     ///
@@ -229,6 +231,9 @@ pub struct FunctionOutputs {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TypeOutputs {
+    /// Name of the file that contains this type.
+    pub filename: String,
+
     /// Progress: a field of this type contains a raw pointer.
     ///
     /// For type alias like `type Foo = *const u8;`, we treat the RHS as a field named "type", so
@@ -240,7 +245,7 @@ pub struct TypeOutputs {
 impl FunctionOutputs {
     fn calc_total_unsafe(&mut self) {
         let FunctionOutputs {
-            ref mut total_unsafe,
+            ref mut total_unsafe, filename: _,
             is_unsafe_fn, is_mut_static, derefs_raw_ptr, calls_unsafe,
             ref uses_static_mut, ref uses_union_field,
             // Progress, not safety
@@ -261,6 +266,7 @@ impl FunctionOutputs {
 impl TypeOutputs {
     fn total_unsafe(&self) -> usize {
         let TypeOutputs {
+            filename: _,
             // Progress, not safety
             field_contains_raw_ptr: _,
         } = *self;
@@ -448,6 +454,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
             let key: String = item.name();
             let mut value = FunctionOutputs {
                 total_unsafe: 0,    // Calculated later
+                filename: item.span().get_filename(),
                 is_unsafe_fn: is_unsafe_fn(item),
                 is_mut_static: is_mut_static(item),
                 derefs_raw_ptr: v.derefs_raw_ptr,
@@ -479,6 +486,7 @@ pub fn process(tcx: TyCtxt) -> Outputs {
     for td in crate_type_defs(tcx) {
         let key: String = td.name();
         let value = TypeOutputs {
+            filename: td.span().get_filename(),
             field_contains_raw_ptr: type_def_field_contains_raw_ptr(&td),
         };
         out.total_unsafe += value.total_unsafe();

--- a/tools/rust-toolchain.toml
+++ b/tools/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-05-11"
+channel = "nightly-2026-06-17"
 components = ["rustc-dev", "rust-src", "llvm-tools"]


### PR DESCRIPTION
* Bump C2Rust submodule to get the reorganize-definitions fix in immunant/c2rust#1859
* Bump nightly toolchain for tools (2026-05-11 -> 2026-06-17) to fix a `rustc_public` (Stable MIR) panic on associated type impls
* Add filenames to `find-unsafe2` outputs
* Adjust random targeting to focus on one file at a time
* Various minor changes to the agent prompt 