### PR TITLE
Make the agent's life a little bit easier

### DIFF
--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -5,6 +5,7 @@ Rewrite operations using AI agent tools, such as codex-cli
 import os
 from pathlib import Path
 import re
+import shlex
 
 from pathspec.pathspec import PathSpec
 
@@ -15,6 +16,7 @@ from .mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
 from .sandbox import run_sandbox
 
 AGENT_DEFAULT_MODEL = "gpt-5.5-2026-04-23"
+BASELINE_DIR = '/tmp/crisp-baseline'
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
 
@@ -96,6 +98,29 @@ def _inject_codex_auth(sb):
     sb.checkout_file_untracked('.codex/auth.json', auth_bytes)
 
 
+def _normalize_baseline_path(path: str) -> str:
+    path = os.path.normpath(path)
+    if os.path.isabs(path) or path.startswith(os.pardir + os.sep) or path == os.pardir:
+        raise ValueError(f'baseline path must be relative to the sandbox work dir: {path!r}')
+    return path
+
+
+def _with_baseline_setup(sb, cmd: list[str], baseline_paths: list[str]) -> list[str]:
+    if len(baseline_paths) == 0:
+        return cmd
+
+    script_lines = [f'rm -rf {shlex.quote(BASELINE_DIR)}']
+    for path in baseline_paths:
+        path = _normalize_baseline_path(path)
+        src = sb.join(path)
+        dest = os.path.join(BASELINE_DIR, path)
+        script_lines.append(f'mkdir -p {shlex.quote(os.path.dirname(dest))}')
+        script_lines.append(f'cp -a {shlex.quote(src)} {shlex.quote(dest)}')
+    script_lines.append(f'exec {shlex.join(cmd)}')
+
+    return ['sh', '-c', ' && '.join(script_lines)]
+
+
 def run_rewrite(
     cfg: Config,
     mvir: MVIR,
@@ -108,6 +133,7 @@ def run_rewrite(
     codex_login: bool = False,
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
+    baseline_paths: list[str] | None = None,
 ) -> tuple[TreeNode, TreeNode]:
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
@@ -124,6 +150,8 @@ def run_rewrite(
 
     if env is None:
         env = {}
+    if baseline_paths is None:
+        baseline_paths = []
 
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(input_code)
@@ -144,6 +172,7 @@ def run_rewrite(
             '--skip-git-repo-check',
             prompt,
         ], codex_login=codex_login)
+        codex_cmd = _with_baseline_setup(sb, codex_cmd, baseline_paths)
         print(codex_cmd)
         all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -162,12 +162,14 @@ cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
 This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
 
-The current unsafe analysis JSON is available under `unsafe_json/*.json`, and the absolute directory is in `$FIND_UNSAFE2_JSON_DIR`. Do not use `grep`, `cat`, or `sed` to dump these JSON files; they are large single-line files and that will flood your transcript. Use `jq` to extract exactly what you need. Each JSON file has this shape:
+The baseline unsafe analysis JSON for the start of this turn is available under `unsafe_json/*.json`, and the absolute directory is in `$FIND_UNSAFE2_JSON_DIR`. `cargo check-unsafe2` uses this baseline JSON to compare your edited code against the start-of-turn code. Do not delete, overwrite, or regenerate files under `unsafe_json/`, because that can make `cargo check-unsafe2` compare your edits against themselves and miss newly introduced unsafe code.
+
+Do not use `grep`, `cat`, or `sed` to dump these JSON files; they are large single-line files and that will flood your transcript. Use `jq` to extract exactly what you need. Each JSON file has this shape:
 - `.total_unsafe`: the total counted unsafe operations, excluding FFI entry points.
 - `.fns`: map from fully qualified function name to per-function counts. Useful fields include `total_unsafe`, `is_unsafe_fn`, `is_mut_static`, `derefs_raw_ptr`, `calls_unsafe`, `uses_static_mut`, `uses_union_field`, `uses_foreign_fn`, `casts_int_to_ptr`, `sig_contains_raw_ptr`, and `is_ffi_entry_point`.
 - `.types`: map from fully qualified type name to `field_contains_raw_ptr`, a map from field name to raw-pointer count.
 
-Useful queries:
+Useful baseline queries:
 ```sh
 # Show the functions that still count as unsafe, largest first.
 jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, (.value.uses_static_mut | length), (.value.uses_union_field | length), .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' unsafe_json/*.json | sort -nr
@@ -178,6 +180,16 @@ jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {{name
 # List raw-pointer fields in types.
 jq -r '.types | to_entries[] | .key as $type | .value.field_contains_raw_ptr | to_entries[] | select(.value > 0) | [$type, .key, .value] | @tsv' unsafe_json/*.json
 ```
+
+If you need an up-to-date unsafe-count report for your edited code, write it to a separate temporary directory and query that directory instead of `unsafe_json/`:
+```sh
+rm -rf /tmp/current-unsafe-json
+FIND_UNSAFE2_JSON_DIR=/tmp/current-unsafe-json cargo find-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
+jq -r '.total_unsafe' /tmp/current-unsafe-json/*.json
+jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' /tmp/current-unsafe-json/*.json | sort -nr
+```
+
+After using `cargo find-unsafe2` for a current report, still run `cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml` before returning so your final edits are checked against the original baseline JSON.
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -149,6 +149,12 @@ For FFI entry points, the following rules apply:
 
 {after_refactoring_instruction}
 
+This workspace is not a Git repository, so `git diff` and `git status` will not show your changes. A baseline copy of the Rust code from the start of this turn is available at `/tmp/crisp-baseline/{cargo_dir_path}`. To inspect your current changes, run:
+```sh
+git diff --no-index /tmp/crisp-baseline/{cargo_dir_path} {cargo_dir_path} || true
+```
+Do not edit files under `/tmp/crisp-baseline`, as this will break your ability to diff cleanly.
+
 Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:
 ```sh
 cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
@@ -1203,6 +1209,7 @@ class Workflow:
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ],
             find_unsafe2_json_dir = analysis.UNSAFE_JSON_DIR,
+            baseline_paths = [cargo_dir],
         )
 
     @step

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -172,7 +172,7 @@ Useful queries:
 jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, (.value.uses_static_mut | length), (.value.uses_union_field | length), .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' unsafe_json/*.json | sort -nr
 
 # Inspect one family of functions by name.
-jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {name: .key, info: .value}' unsafe_json/*.json
+jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {{name: .key, info: .value}}' unsafe_json/*.json
 
 # List raw-pointer fields in types.
 jq -r '.types | to_entries[] | .key as $type | .value.field_contains_raw_ptr | to_entries[] | select(.value > 0) | [$type, .key, .value] | @tsv' unsafe_json/*.json

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -174,13 +174,13 @@ Do not use `grep`, `cat`, or `sed` to dump these JSON files; they are large sing
 Useful baseline queries:
 ```sh
 # Show the functions that still count as unsafe, largest first.
-jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, (.value.uses_static_mut | length), (.value.uses_union_field | length), .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' unsafe_json/*.json | sort -nr
+jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, (.value.uses_static_mut | length), (.value.uses_union_field | length), .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' "$FIND_UNSAFE2_JSON_DIR"/*.json | sort -nr
 
 # Inspect one family of functions by name.
-jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {{name: .key, info: .value}}' unsafe_json/*.json
+jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {{name: .key, info: .value}}' "$FIND_UNSAFE2_JSON_DIR"/*.json
 
 # List raw-pointer fields in types.
-jq -r '.types | to_entries[] | .key as $type | .value.field_contains_raw_ptr | to_entries[] | select(.value > 0) | [$type, .key, .value] | @tsv' unsafe_json/*.json
+jq -r '.types | to_entries[] | .key as $type | .value.field_contains_raw_ptr | to_entries[] | select(.value > 0) | [$type, .key, .value] | @tsv' "$FIND_UNSAFE2_JSON_DIR"/*.json
 ```
 
 If you need an up-to-date unsafe-count report for your edited code, write it to a separate temporary directory and query that directory instead of `unsafe_json/`:

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -149,10 +149,11 @@ For FFI entry points, the following rules apply:
 
 {after_refactoring_instruction}
 
-This workspace is not a Git repository, so `git diff` and `git status` will not show your changes. A baseline copy of the Rust code from the start of this turn is available at `/tmp/crisp-baseline/{cargo_dir_path}`. To inspect your current changes, run:
+This workspace is not a Git repository, so `git diff` and `git status` will not show your changes. A baseline copy of the Rust code from the start of this turn is available at `/tmp/crisp-baseline/{cargo_dir_path}`. To inspect your current changes, prefer diffing individual source files against their baseline copies, for example:
 ```sh
-git diff --no-index /tmp/crisp-baseline/{cargo_dir_path} {cargo_dir_path} || true
+git diff --no-index /tmp/crisp-baseline/{cargo_dir_path}/path/to/file.rs {cargo_dir_path}/path/to/file.rs || true
 ```
+Replace `path/to/file.rs` with the relative path of the source file you edited. Avoid directory-level diffs after running `cargo build`, because generated files under `target/` can flood the output. Also avoid `git diff --no-index OLD_DIR NEW_DIR -- path`; `--no-index` expects two concrete paths, so pass the two files directly.
 Do not edit files under `/tmp/crisp-baseline`, as this will break your ability to diff cleanly.
 
 Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -149,11 +149,11 @@ For FFI entry points, the following rules apply:
 
 {after_refactoring_instruction}
 
-This workspace is not a Git repository, so `git diff` and `git status` will not show your changes. A baseline copy of the Rust code from the start of this turn is available at `/tmp/crisp-baseline/{cargo_dir_path}`. To inspect your current changes, prefer diffing individual source files against their baseline copies, for example:
+This workspace is not a Git repository, so `git diff` and `git status` will not show your changes. A baseline copy of the Rust code from the start of this turn is available at `/tmp/crisp-baseline/{cargo_dir_path}`. To inspect your current changes, use `diff -u` on individual source files against their baseline copies, for example:
 ```sh
-git diff --no-index /tmp/crisp-baseline/{cargo_dir_path}/path/to/file.rs {cargo_dir_path}/path/to/file.rs || true
+diff -u /tmp/crisp-baseline/{cargo_dir_path}/path/to/file.rs {cargo_dir_path}/path/to/file.rs || true
 ```
-Replace `path/to/file.rs` with the relative path of the source file you edited. Avoid directory-level diffs after running `cargo build`, because generated files under `target/` can flood the output. Also avoid `git diff --no-index OLD_DIR NEW_DIR -- path`; `--no-index` expects two concrete paths, so pass the two files directly.
+Replace `path/to/file.rs` with the relative path of the source file you edited. Avoid directory-level diffs after running `cargo build`, because generated files under `target/` can flood the output.
 Do not edit files under `/tmp/crisp-baseline`, as this will break your ability to diff cleanly.
 
 Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -164,6 +164,8 @@ This will report an error for any unsafe code that was improperly added during y
 
 The baseline unsafe analysis JSON for the start of this turn is available under `unsafe_json/*.json`, and the absolute directory is in `$FIND_UNSAFE2_JSON_DIR`. `cargo check-unsafe2` uses this baseline JSON to compare your edited code against the start-of-turn code. Do not delete, overwrite, or regenerate files under `unsafe_json/`, because that can make `cargo check-unsafe2` compare your edits against themselves and miss newly introduced unsafe code.
 
+When searching source text with `rg` or similar tools, search inside `{cargo_dir_path}/` rather than from the workspace root, for example `rg "PATTERN" {cargo_dir_path}` or `rg "PATTERN" {cargo_dir_path}/src`. Broad workspace-level searches can accidentally match the large `unsafe_json/*.json` files and flood your transcript. If you need information from `unsafe_json/*.json`, use the targeted `jq` queries below instead of text search.
+
 Do not use `grep`, `cat`, or `sed` to dump these JSON files; they are large single-line files and that will flood your transcript. Use `jq` to extract exactly what you need. Each JSON file has this shape:
 - `.total_unsafe`: the total counted unsafe operations, excluding FFI entry points.
 - `.fns`: map from fully qualified function name to per-function counts. Useful fields include `total_unsafe`, `is_unsafe_fn`, `is_mut_static`, `derefs_raw_ptr`, `calls_unsafe`, `uses_static_mut`, `uses_union_field`, `uses_foreign_fn`, `casts_int_to_ptr`, `sig_contains_raw_ptr`, and `is_ffi_entry_point`.

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -160,6 +160,23 @@ Your changes must not introduce new unsafe code within implementation functions.
 cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
 This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
+
+The current unsafe analysis JSON is available under `unsafe_json/*.json`, and the absolute directory is in `$FIND_UNSAFE2_JSON_DIR`. Do not use `grep`, `cat`, or `sed` to dump these JSON files; they are large single-line files and that will flood your transcript. Use `jq` to extract exactly what you need. Each JSON file has this shape:
+- `.total_unsafe`: the total counted unsafe operations, excluding FFI entry points.
+- `.fns`: map from fully qualified function name to per-function counts. Useful fields include `total_unsafe`, `is_unsafe_fn`, `is_mut_static`, `derefs_raw_ptr`, `calls_unsafe`, `uses_static_mut`, `uses_union_field`, `uses_foreign_fn`, `casts_int_to_ptr`, `sig_contains_raw_ptr`, and `is_ffi_entry_point`.
+- `.types`: map from fully qualified type name to `field_contains_raw_ptr`, a map from field name to raw-pointer count.
+
+Useful queries:
+```sh
+# Show the functions that still count as unsafe, largest first.
+jq -r '.fns | to_entries[] | select(.value.total_unsafe > 0) | [.value.total_unsafe, .key, .value.derefs_raw_ptr, .value.calls_unsafe, (.value.uses_static_mut | length), (.value.uses_union_field | length), .value.is_unsafe_fn, .value.is_ffi_entry_point] | @tsv' unsafe_json/*.json | sort -nr
+
+# Inspect one family of functions by name.
+jq -r '.fns | to_entries[] | select(.key | test("FUNCTION_OR_PATTERN")) | {name: .key, info: .value}' unsafe_json/*.json
+
+# List raw-pointer fields in types.
+jq -r '.types | to_entries[] | .key as $type | .value.field_contains_raw_ptr | to_entries[] | select(.value > 0) | [$type, .key, .value] | @tsv' unsafe_json/*.json
+```
 '''
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''


### PR DESCRIPTION
This PR makes a couple of changes to smooth out some speedbumps I see the agent hitting regularly:

- **Give the agent a way to diff the current workspace** against the original code for the current turn, and also tell it that it's not in a Git repo. The agent regularly tries to `git diff` to see its pending changes, which doesn't work because it's not in a Git repo. This PR adds an additional copy of the starting code for the turn in a separate directory, and adds instructions to tell the agent how it can diff against that baseline to check its pending changes.
- **Explain more of how the unsafe JSON works** and how to interact with it.
  - Explain where to find the baseline JSON and that check-unsafe2 does not update that file.
  - Tell it how to use find-unsafe2 to generate updated unsafety counts without overwriting the baseline JSON.
  - Tell it how to avoid dumping the raw JSON into context, including avoiding common ways it accidentally dumps the full JSON e.g. running `rg` on the whole workspace.
  - Give it advice on how to use `jq` to more cleanly query the unsafety JSON.

These changes should somewhat help reduce unnecessary token usage and help the agent work a bit faster. I doubt this will have any impact on performance, at least wrt the quality of the translated code, but it should reduce token usage and help the agent move a bit more quickly. I don't see a massive difference on cJSON, but I think this will have a bigger impact on larger projects, where dumping the full unsafety JSON into context can be a pretty massive amount of context flooding.

Also, the instructions on how to avoid overwriting the unsafety JSON should help reduce the number of rejected edits. When I tested these changes in combination with the fix in https://github.com/GaloisInc/Tractor-Crisp/pull/151, I was able to do two full translations of cJSON with 0 rejected edits.