### PR TITLE
crisp: add model selection configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ cd /root/project
 # Set up environment variables for accessing OpenAI models
 export CRISP_API_BASE=https://api.openai.com/v1
 export CRISP_API_KEY=sk-your-api-key-here
-export CRISP_API_MODEL=gpt-5-2025-08-07
+
+# Optional: override the `models.agent`, `models.rewriter`, etc. selections
+# in crisp.toml for this run.
+#export CRISP_API_MODEL=gpt-5.6-sol
 
 # As an alternative, you can direct CRISP to connect to llama.cpp or another
 # OpenAI-compatible provider running on the host machine:

--- a/crisp.toml.example
+++ b/crisp.toml.example
@@ -21,6 +21,15 @@ set -e
 cargo build --manifest-path rust/Cargo.toml
 """
 
+# Choose the models used by the different CRISP operations.
+[models]
+# Used by the Codex agent safety-refactoring mode.
+agent = "gpt-5.6-terra"
+# Used by the c2rust postprocessing pass.
+postprocess = "gpt-5.6-luna"
+# Used by direct LLM rewrite operations.  If omitted, CRISP asks the API for
+# its available models and uses the first one.
+#rewriter = "gpt-5.6-terra"
 
 [transpile]
 

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -14,8 +14,6 @@ from .error import CrispError
 from .mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
 from .sandbox import run_sandbox
 
-AGENT_DEFAULT_MODEL = "gpt-5.5-2026-04-23"
-
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
 
 def _snapshot_to_family_alias(model: str) -> str:
@@ -26,7 +24,7 @@ def _snapshot_to_family_alias(model: str) -> str:
     m = _SNAPSHOT_SUFFIX.match(model)
     return m.group("alias") if m else model
 
-def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> list[str]:
+def _codex_command(cfg: Config, subcmd: str, args: list[str], codex_login: bool = False) -> list[str]:
     cmd = ['codex', subcmd]
 
     if codex_login:
@@ -34,7 +32,7 @@ def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> l
         # override the model; everything else uses codex's defaults.
         # The --model flag does not support snapshot-style model identifiers so
         # we attempt to convert snapshots to model family aliases.
-        model = _snapshot_to_family_alias(llm.API_MODEL or AGENT_DEFAULT_MODEL)
+        model = _snapshot_to_family_alias(llm.API_MODEL or cfg.models.agent)
         cmd += ['--model', model]
     else:
         config_settings = {
@@ -43,7 +41,7 @@ def _codex_command(subcmd: str, args: list[str], codex_login: bool = False) -> l
             #'model_providers.crisp.api_key': llm.API_KEY or 'sk-no-api-key',
             'model_providers.crisp.env_key': 'CRISP_API_KEY',
             'model_provider': 'crisp',
-            'model': llm.API_MODEL or AGENT_DEFAULT_MODEL,
+            'model': llm.API_MODEL or cfg.models.agent,
             # TODO: OpenAI pricing is based on input and output tokens, with 
             # long context tokens costing twice as much as short context ones.
             # We might want to set limits to avoid the long context pricing.
@@ -139,7 +137,7 @@ def run_rewrite(
         codex_dir = sb.join(".codex")
         mkdir_codex = ['mkdir', '-p', codex_dir]
 
-        codex_cmd = _codex_command('exec', [
+        codex_cmd = _codex_command(cfg, 'exec', [
             '--dangerously-bypass-approvals-and-sandbox',
             '--skip-git-repo-check',
             prompt,

--- a/crisp/config.py
+++ b/crisp/config.py
@@ -39,6 +39,13 @@ class ConfigBase:
         return cls.from_dict(d, path, **kwargs)
 
 @dataclass(frozen = True)
+class ModelsConfig(ConfigBase):
+    agent: str  = "gpt-5.6-terra"
+    postprocess: str = "gpt-5.6-luna"
+    # `rewriter = None` means call `/v1/models` and pick the first from the list.
+    rewriter: str | None = None
+
+@dataclass(frozen = True)
 class Config(ConfigBase):
     config_path: str
 
@@ -58,10 +65,9 @@ class Config(ConfigBase):
     base_dir: str = '.'
     mvir_storage_dir: str = 'crisp-storage'
     on_accept: str | None = None
-    # `model = None` means call `/v1/models` and pick the first from the list.
-    model: str | None = None
 
-    models: dict[str, 'ModelConfig'] = field(default_factory=dict)
+    models: ModelsConfig = field(default_factory=ModelsConfig)
+    model_options: dict[str, 'ModelOptionsConfig'] = field(default_factory=dict)
 
     def __post_init__(self):
         config_dir = os.path.dirname(self.config_path)
@@ -171,7 +177,7 @@ class TranspileArtifactConfig(ConfigBase):
             os.path.join(config_dir, self.hayroll_project_dir))
 
 @dataclass(frozen = True)
-class ModelConfig(ConfigBase):
+class ModelOptionsConfig(ConfigBase):
     prefill: str = ''
     prefill_think: str = ''
     # Which mode to use for embedding files into the LLM input/output.  The

--- a/crisp/llm.py
+++ b/crisp/llm.py
@@ -6,7 +6,7 @@ import re
 import requests
 
 from . import llm_format
-from .config import Config, ModelConfig
+from .config import Config, ModelOptionsConfig
 from .error import CrispError
 from .mvir import MVIR, FileNode, TreeNode, LlmOpNode
 from .util import ChunkPrinter
@@ -240,11 +240,11 @@ def run_rewrite(
         think: bool = False,
         separate_system_prompt: bool = False
         ) -> tuple[TreeNode, LlmOpNode]:
-    model = API_MODEL or cfg.model
+    model = API_MODEL or cfg.models.rewriter
     if model is None:
         model = get_default_model()
     print('using model %r' % model)
-    model_cfg = cfg.models.get(model) or ModelConfig()
+    model_cfg = cfg.model_options.get(model) or ModelOptionsConfig()
 
     if LLM_FILE_FORMATTER is None:
         file_formatter = llm_format.get_file_formatter(


### PR DESCRIPTION
- existing `models` configuration key becomes `model_options`
- also changes agent default to gpt-5.6-terra  which is better and cheaper than the current gpt-5.5 default.
- updated README and `crisp.toml.example`

We need per-task/stage model selection for #131 and it would also be good for #152 