### PR TITLE
Give the agent a little Git repo in the sandbox

### DIFF
--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -132,6 +132,23 @@ def run_rewrite(
         if planning_files is not None:
             sb.checkout(planning_files)
 
+        # Each agent turn gets a fresh sandbox, so make the checked-out files
+        # the baseline of a small local repository.  This lets the agent use
+        # ordinary Git commands (especially `git diff`) to inspect its edits.
+        # `git commit -a` alone does not include the initially untracked files,
+        # hence the explicit add before creating the baseline commit.
+        init_git_repo = [
+            'sh', '-c',
+            'git init -q && git add --all && '
+            'git -c user.name=CRISP -c user.email=crisp@localhost '
+            'commit --quiet -m "CRISP sandbox baseline"',
+        ]
+        exit_code, logs = sb.run(init_git_repo, cwd=cwd, stream=True)
+        if exit_code != 0:
+            raise CrispError(
+                f'failed to initialize Git repository in agent sandbox: '
+                f'exit code {exit_code}')
+
         if codex_login:
             print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
             _inject_codex_auth(sb)
@@ -163,6 +180,7 @@ def run_rewrite(
                 raise CrispError(f'codex-cli failed: exit code {exit_code}')
 
         ignore_lines = [
+            '.git/',
             '__pycache__/',
             'build/',
             'build-ninja/',

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -5,6 +5,7 @@ Rewrite operations using AI agent tools, such as codex-cli
 import os
 from pathlib import Path
 import re
+import shlex
 
 from pathspec.pathspec import PathSpec
 
@@ -137,9 +138,23 @@ def run_rewrite(
         # ordinary Git commands (especially `git diff`) to inspect its edits.
         # `git commit -a` alone does not include the initially untracked files,
         # hence the explicit add before creating the baseline commit.
+        gitignore_lines = [
+            '# Cargo build output',
+            '/target/',
+            '**/*.rs.bk',
+            '*.pdb',
+        ]
+        if find_unsafe2_json_dir is not None:
+            gitignore_lines.extend([
+                '# CRISP unsafe-analysis results',
+                f'{find_unsafe2_json_dir.rstrip("/")}/',
+            ])
+        write_gitignore = (
+            f'printf %s {shlex.quote("\\n".join(gitignore_lines) + "\\n")} '
+            '> .gitignore')
         init_git_repo = [
             'sh', '-c',
-            'git init -q && git add --all && '
+            f'git init -q && {write_gitignore} && git add --all && '
             'git -c user.name=CRISP -c user.email=crisp@localhost '
             'commit --quiet -m "CRISP sandbox baseline"',
         ]

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -5,7 +5,6 @@ Rewrite operations using AI agent tools, such as codex-cli
 import os
 from pathlib import Path
 import re
-import shlex
 
 from pathspec.pathspec import PathSpec
 
@@ -133,66 +132,63 @@ def run_rewrite(
         if planning_files is not None:
             sb.checkout(planning_files)
 
-        # Each agent turn gets a fresh sandbox, so make the checked-out files
-        # the baseline of a small local repository.  This lets the agent use
-        # ordinary Git commands (especially `git diff`) to inspect its edits.
-        # `git commit -a` alone does not include the initially untracked files,
-        # hence the explicit add before creating the baseline commit.
+        # Each agent turn gets a fresh sandbox, so make the entire sandbox
+        # (including input_code, unsafety JSON, and planning_files) the baseline
+        # of a small local repository.  The repository is rooted at `.` even
+        # when Codex runs in a narrower `cwd`; Git will find the parent repo.
+        # This lets the agent use ordinary Git commands (especially `git diff`)
+        # to inspect its edits.  `git commit -a` alone does not include the
+        # initially untracked files, hence the explicit add before creating the
+        # baseline commit.
         gitignore_lines = [
             '# Cargo build output',
-            '/target/',
-            '**/*.rs.bk',
-            '*.pdb',
+            'target/',
         ]
         if find_unsafe2_json_dir is not None:
             gitignore_lines.extend([
                 '# CRISP unsafe-analysis results',
                 f'{find_unsafe2_json_dir.rstrip("/")}/',
             ])
-        write_gitignore = (
-            f'printf %s {shlex.quote("\\n".join(gitignore_lines) + "\\n")} '
-            '> .gitignore')
-        init_git_repo = [
-            'sh', '-c',
-            f'git init -q && {write_gitignore} && git add --all && '
+        gitignore_file = FileNode.new(
+            mvir, '\n'.join(gitignore_lines) + '\n')
+        sb.checkout_file('.gitignore', gitignore_file)
+        init_git_repo = (
+            'git init -q && git add --all && '
             'git -c user.name=CRISP -c user.email=crisp@localhost '
-            'commit --quiet -m "CRISP sandbox baseline"',
-        ]
-        exit_code, logs = sb.run(init_git_repo, cwd=cwd, stream=True)
-        if exit_code != 0:
-            raise CrispError(
-                f'failed to initialize Git repository in agent sandbox: '
-                f'exit code {exit_code}')
+            'commit --quiet -m "CRISP sandbox baseline"')
+        exit_code, logs = sb.run(init_git_repo, cwd='.', shell=True, stream=True)
+        git_init_failed = exit_code != 0
 
-        if codex_login:
-            print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
-            _inject_codex_auth(sb)
+        if not git_init_failed:
+            if codex_login:
+                print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
+                _inject_codex_auth(sb)
 
-        codex_dir = sb.join(".codex")
-        mkdir_codex = ['mkdir', '-p', codex_dir]
+            codex_dir = sb.join(".codex")
+            mkdir_codex = ['mkdir', '-p', codex_dir]
 
-        codex_cmd = _codex_command('exec', [
-            '--dangerously-bypass-approvals-and-sandbox',
-            '--skip-git-repo-check',
-            prompt,
-        ], codex_login=codex_login)
-        print(codex_cmd)
-        all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
+            codex_cmd = _codex_command('exec', [
+                '--dangerously-bypass-approvals-and-sandbox',
+                '--skip-git-repo-check',
+                prompt,
+            ], codex_login=codex_login)
+            print(codex_cmd)
+            all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 
-        if 'CODEX_HOME' not in env:
-            env['CODEX_HOME'] = codex_dir
-        if find_unsafe2_json_dir is not None:
-            env['FIND_UNSAFE2_JSON_DIR'] = sb.join(find_unsafe2_json_dir)
+            if 'CODEX_HOME' not in env:
+                env['CODEX_HOME'] = codex_dir
+            if find_unsafe2_json_dir is not None:
+                env['FIND_UNSAFE2_JSON_DIR'] = sb.join(find_unsafe2_json_dir)
 
-        exit_code = 0
-        logs = b''
-        for cmd in all_cmds:
-            exit_code, logs2 = sb.run(cmd, cwd=cwd, stream=True, env=env)
-            logs += logs2
+            exit_code = 0
+            logs = b''
+            for cmd in all_cmds:
+                exit_code, logs2 = sb.run(cmd, cwd=cwd, stream=True, env=env)
+                logs += logs2
 
-            # TODO: ensure API key doesn't get included in the AgentOpNode
-            if exit_code != 0:
-                raise CrispError(f'codex-cli failed: exit code {exit_code}')
+                # TODO: ensure API key doesn't get included in the AgentOpNode
+                if exit_code != 0:
+                    raise CrispError(f'codex-cli failed: exit code {exit_code}')
 
         ignore_lines = [
             '.git/',
@@ -252,5 +248,10 @@ def run_rewrite(
     )
     # Record operations and timestamps in the `op_history` reflog.
     mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
+
+    if git_init_failed:
+        raise CrispError(
+            f'failed to initialize Git repository in agent sandbox: '
+            f'exit code {exit_code}')
 
     return (output_code, output_plans)

--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -155,9 +155,8 @@ def run_rewrite(
             'git -c user.name=CRISP -c user.email=crisp@localhost '
             'commit --quiet -m "CRISP sandbox baseline"')
         exit_code, logs = sb.run(init_git_repo, cwd='.', shell=True, stream=True)
-        git_init_failed = exit_code != 0
 
-        if not git_init_failed:
+        if exit_code == 0:
             if codex_login:
                 print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
                 _inject_codex_auth(sb)
@@ -178,15 +177,13 @@ def run_rewrite(
             if find_unsafe2_json_dir is not None:
                 env['FIND_UNSAFE2_JSON_DIR'] = sb.join(find_unsafe2_json_dir)
 
-            exit_code = 0
-            logs = b''
             for cmd in all_cmds:
                 exit_code, logs2 = sb.run(cmd, cwd=cwd, stream=True, env=env)
                 logs += logs2
 
                 # TODO: ensure API key doesn't get included in the AgentOpNode
                 if exit_code != 0:
-                    raise CrispError(f'codex-cli failed: exit code {exit_code}')
+                    break
 
         ignore_lines = [
             '.git/',
@@ -247,9 +244,8 @@ def run_rewrite(
     # Record operations and timestamps in the `op_history` reflog.
     mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
 
-    if git_init_failed:
+    if exit_code != 0:
         raise CrispError(
-            f'failed to initialize Git repository in agent sandbox: '
-            f'exit code {exit_code}')
+            f'agent invocation failed: exit code {exit_code}', n_op)
 
     return (output_code, output_plans)


### PR DESCRIPTION
I've observed the agent trying to run `git diff` and a couple of other Git operations in the sandbox, which currently does not work because we don't give the agent a Git repo. https://github.com/GaloisInc/Tractor-Crisp/pull/155 attempts to fix this by telling the agent it's not in a Git repo and giving it alternate instructions for diffing the state of the code. @thedataking suggested that we could instead init a Git repo within the sandbox so that the agent could use the Git commands it's already comfortable with. That wouldn't expose the full MVIR history to the agent, but would allow things like `git diff` to work. I tested out this out and looks like the agent mainly tries to do `git diff` and `git restore`, I haven't seen it trying to search through the commit history or do other operations that wouldn't work.

One other minor fix in here related to #155 is that I've included the unsafe JSON dir in the `.gitignore` to see if that helps the agent to not accidentally dump. This doesn't seem to matter in practice since the agent explicitly points `rg` at the `unsafe_json` dir, overriding the `.gitignore` 🤷 