### PR TITLE
agent: Update prompt for planning step and use custom subagents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN cargo-docker-clean.sh /opt/crisp-tools/install-all.sh
 # Install codex-cli
 RUN mkdir /opt/codex-cli \
     && cd /opt/codex-cli \
-    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.144.3/codex-x86_64-unknown-linux-musl.tar.gz \
+    && codex_url=https://github.com/openai/codex/releases/download/rust-v0.145.0/codex-x86_64-unknown-linux-musl.tar.gz \
     && wget --quiet "$codex_url" \
     && tar -xzf "$(basename "$codex_url")" \
     && ln -s "$PWD/codex-x86_64-unknown-linux-musl" /usr/local/bin/codex \

--- a/crisp/agent/__init__.py
+++ b/crisp/agent/__init__.py
@@ -3,18 +3,34 @@ Rewrite operations using AI agent tools, such as codex-cli
 """
 
 import os
-from pathlib import Path
 import re
+from pathlib import Path
+from typing import Sequence
 
 from pathspec.pathspec import PathSpec
 
-from . import llm
-from .config import Config
-from .error import CrispError
-from .mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
-from .sandbox import run_sandbox
+from .. import llm
+from ..config import Config
+from ..error import CrispError
+from ..mvir import MVIR, TreeNode, FileNode, CodexAgentOpNode
+from ..sandbox import run_sandbox
+
+# Repo-side agent assets; installed into the sandbox as `.codex/`, the
+# directory codex-cli searches for project-level agents and instructions.
+_CODEX_ASSET_DIR = Path(__file__).parent / 'codex'
+_CODEX_SAFETY_CONSTRAINTS = 'safety_constraints.md'
+
+PLANNING_CODEX_AGENTS = (
+    'collections_analyst',
+    'ffi_abi_analyst',
+    'libc_analyst',
+    'macro_analyst',
+    'ownership_analyst',
+    'strings_analyst',
+)
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
+
 
 def _snapshot_to_family_alias(model: str) -> str:
     """
@@ -43,11 +59,11 @@ def _codex_command(cfg: Config, subcmd: str, args: list[str],
             'model_providers.crisp.env_key': 'CRISP_API_KEY',
             'model_provider': 'crisp',
             'model': llm.API_MODEL or model,
-            # TODO: OpenAI pricing is based on input and output tokens, with 
+            # TODO: OpenAI pricing is based on input and output tokens, with
             # long context tokens costing twice as much as short context ones.
             # We might want to set limits to avoid the long context pricing.
             #
-            # Example config limits for gpt-5.5:  
+            # Example config limits for gpt-5.5:
             #
             # 'model_context_window': 272000
             # 'model_auto_compact_token_limit' = 240000
@@ -56,7 +72,7 @@ def _codex_command(cfg: Config, subcmd: str, args: list[str],
             cmd += ['-c', f'{k}={v}']
 
     # Fast (aka. priority) mode delivers 1.5 faster tokens at 2.5x credit use [0].
-    # The service tier selection mechanism can be entirely disabled by setting 
+    # The service tier selection mechanism can be entirely disabled by setting
     # `fast_mode == false` [1].
     #
     # [0]: https://developers.openai.com/codex/speed
@@ -65,9 +81,14 @@ def _codex_command(cfg: Config, subcmd: str, args: list[str],
         '-c', 'model_reasoning_effort="high"',
         '-c', 'features.fast_mode=false',
     ]
-    
+
     cmd += args
     return cmd
+
+def _checkout_bytes(sb, mvir: MVIR, rel_path: str, body: bytes):
+    """Add an ephemeral file to any supported CRISP sandbox."""
+    sb.checkout_file(rel_path, FileNode.new(mvir, body))
+
 
 def _inject_codex_auth(sb):
     """Copy the host's ``auth.json`` into the container's work
@@ -92,7 +113,42 @@ def _inject_codex_auth(sb):
     with open(host_auth, 'rb') as f:
         auth_bytes = f.read()
 
+    # Do not create an MVIR FileNode for credentials: that would persist the
+    # secret in CRISP's content-addressed storage.
     sb.checkout_file_untracked('.codex/auth.json', auth_bytes)
+
+
+def _inject_codex_agents(
+    sb,
+    mvir: MVIR,
+    agent_names: Sequence[str],
+):
+    """Install selected agent profiles from `codex/` into the sandbox's
+    `.codex/`, where codex-cli discovers them."""
+    if not agent_names:
+        return
+
+    available = {path.stem: path for path in _CODEX_ASSET_DIR.glob('*.toml')}
+    unknown = sorted(set(agent_names) - available.keys())
+    if unknown:
+        raise CrispError(
+            f'unknown Codex agent profile(s): {", ".join(unknown)}')
+
+    constraints = _CODEX_ASSET_DIR / _CODEX_SAFETY_CONSTRAINTS
+    _checkout_bytes(
+        sb,
+        mvir,
+        f'.codex/{_CODEX_SAFETY_CONSTRAINTS}',
+        constraints.read_bytes(),
+    )
+    for name in agent_names:
+        profile = available[name]
+        _checkout_bytes(
+            sb,
+            mvir,
+            f'.codex/agents/{profile.name}',
+            profile.read_bytes(),
+        )
 
 
 def run_rewrite(
@@ -108,6 +164,7 @@ def run_rewrite(
     codex_login: bool = False,
     env: dict | None = None,
     find_unsafe2_json_dir: str | None = None,
+    codex_agents: Sequence[str] = (),
 ) -> tuple[TreeNode, TreeNode]:
     # Print the warning in red so it stands out
     WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
@@ -161,6 +218,8 @@ def run_rewrite(
         exit_code, logs = sb.run(init_git_repo, cwd='.', shell=True, stream=True)
 
         if exit_code == 0:
+            _inject_codex_agents(sb, mvir, codex_agents)
+
             if codex_login:
                 print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
                 _inject_codex_auth(sb)

--- a/crisp/agent/codex/collections_analyst.toml
+++ b/crisp/agent/codex/collections_analyst.toml
@@ -1,0 +1,29 @@
+name = "collections_analyst"
+description = "Read-only analyst for translated C containers, custom data structures, and internal function-pointer dispatch."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+Inventory custom lists, queues, trees, maps, sets, growable arrays, buffers,
+pools, arenas, freelists, and other container-like structures. Determine their
+ordering, duplication, iteration, invalidation, allocation, ownership, and
+address-stability semantics from actual uses. Pay special attention to
+intrusive structures and pointers into storage, where a direct Vec or standard
+collection replacement may change behavior.
+
+You also own internal dispatch: non-exported function-pointer tables, vtable
+structs, and state machines built from C function pointers. Recommend enums,
+traits, or plain function items that preserve dispatch behavior. Exported
+callback signatures remain ffi_abi_analyst's.
+
+Recommend standard-library structures or small safe abstractions and identify
+the migration boundary and dependency order for each.
+
+Out of scope: allocation and ownership lifecycle facts (ownership_analyst),
+and string and byte-buffer representations (strings_analyst).
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/agent/codex/ffi_abi_analyst.toml
+++ b/crisp/agent/codex/ffi_abi_analyst.toml
@@ -1,0 +1,26 @@
+name = "ffi_abi_analyst"
+description = "Read-only analyst for exported FFI functions, data symbols, callbacks, and ABI compatibility constraints."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+Inventory the externally visible ABI and determine which Rust details are fixed
+by compatibility. Cover functions with export attributes, exported mutable or
+immutable data symbols, callback signatures, variadic boundaries, by-value
+types, repr attributes, and types passed only behind opaque pointers. Use the
+unsafe-code inventory (`is_ffi_entry_point` in the JSON) to enumerate entry
+points rather than rediscovering them. Trace each exported wrapper to the
+implementation logic it should dispatch to.
+
+Call out signatures and layouts that must remain unchanged, types whose
+internals may safely change, and conversions that belong in minimal FFI
+wrappers.
+
+Out of scope: internal (non-exported) function-pointer tables and dispatch
+(collections_analyst), and internal ownership models (ownership_analyst).
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/agent/codex/libc_analyst.toml
+++ b/crisp/agent/codex/libc_analyst.toml
@@ -1,0 +1,28 @@
+name = "libc_analyst"
+description = "Read-only analyst for replacing C and POSIX library calls with behavior-preserving safe Rust APIs."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+Inventory imported C, POSIX, and platform-library APIs used by implementation
+code. Group them by memory, files and paths, I/O, environment, time, processes,
+synchronization, networking, sorting, and formatting and whatever other
+categories make sense. The inventory's `uses_foreign_fn` maps show which
+functions call which imports. Trace return-value, errno, overflow, locale,
+platform, partial-I/O, and resource lifetime behavior and any other significant
+side effects before proposing replacements.
+
+Recommend safe standard-library operations or narrowly justified safe crates
+(see the dependency policy in the shared constraints), and explain semantic
+gaps where a similarly named Rust API is not equivalent. Prioritize
+replacements that remove unsafe calls from broad call trees.
+
+Out of scope: choosing string and byte-buffer representations. Note
+`str*`/`mem*` call sites on character data and defer the representation choice
+to strings_analyst.
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/agent/codex/macro_analyst.toml
+++ b/crisp/agent/codex/macro_analyst.toml
@@ -1,0 +1,31 @@
+name = "macro_analyst"
+description = "Read-only analyst that finds translated Rust bloated by C macro expansion and recommends safe consolidation."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+C macros expand before translation, so macro-heavy C becomes oversized or
+heavily repeated Rust. Triage cheaply before analyzing:
+
+1. Find translated functions that are disproportionately large, and families
+   of near-identical function bodies; read-only text tools are enough.
+2. For each hit, locate the corresponding C function in the original sources
+   if they are present in the workspace, and confirm the C is much smaller or
+   visibly macro-heavy (function-style #define, X-macros, token pasting,
+   generated tables).
+3. If triage finds no material expansion, return a brief report saying so and
+   stop; do not force findings.
+
+For confirmed hits only, analyze deeply: separate genuine semantic variation
+from mechanical expansion, and recommend Rust functions, traits, constants,
+declarative macros, or small safe abstractions that reduce duplication without
+obscuring control flow, changing evaluation order, duplicating side effects, or
+reintroducing unsafe code. Say whether each consolidation should precede or
+follow the ownership and type migration of the same code; consolidating first
+usually avoids migrating the same expanded body many times.
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/agent/codex/ownership_analyst.toml
+++ b/crisp/agent/codex/ownership_analyst.toml
@@ -1,0 +1,33 @@
+name = "ownership_analyst"
+description = "Read-only analyst for C allocation, ownership, aliasing, lifetimes, mutable globals, and unions."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "xhigh"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+Trace raw-pointer lifecycles and memory provenance across modules. Identify
+allocation and deallocation pairs, transfers of ownership, borrowed views,
+nullable and sentinel states, mutation and aliasing, callback lifetimes,
+address-stability requirements, shared ownership and reference cycles, thread
+sharing, and allocator boundaries. Distinguish facts established by call sites
+from uncertain inferences.
+
+You also own global state and unions. Classify each `static mut` as genuinely
+constant (recommend `static`/`const`), lazily initialized
+(`OnceLock`/`LazyLock`), or truly mutable (atomics, `Mutex`, `RwLock`), and
+recommend replacing each union with an enum or explicit safe fields depending
+on how its variants are actually used. The inventory's `uses_static_mut` and
+`uses_union_field` maps locate the uses.
+
+Recommend suitable safe Rust ownership models such as references, slices,
+Option, Box, Vec, Rc, Arc, Weak, interior mutability, or owned handles,
+including why simpler types would be unsound or behavior-changing.
+
+Out of scope: container-internals mapping (collections_analyst), string and
+byte-buffer representations (strings_analyst), and exported ABI constraints
+(ffi_abi_analyst).
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/agent/codex/safety_constraints.md
+++ b/crisp/agent/codex/safety_constraints.md
@@ -1,0 +1,87 @@
+# CRISP safe-Rust planning constraints
+
+You are a read-only planning analyst. Inspect the code and return evidence to
+the parent agent. Do not edit, create, rename, or delete files, and do not run
+commands that modify the checkout.
+
+The code contains two kinds of functions: implementation functions and FFI
+entry points. A function is an FFI entry point if it has the `#[no_mangle]` or
+`#[export_name]` attribute ("export attributes"). Merely having `unsafe extern
+"C"` qualifiers without export attributes does not make a function an FFI entry
+point. All functions without export attributes are implementation functions.
+
+The following FFI rules are mandatory:
+
+- You must not change the signature. FFI entry point signatures must remain
+  exactly as-is to ensure ABI compatibility with the current version of the
+  code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
+- For struct types that appear only behind a pointer, you may assume the struct
+  is opaque to the user of the library (unless otherwise indicated within the
+  code itself), as is considered best practice in C. This means the struct
+  layout is not part of the ABI, so you may freely change the field types to
+  improve safety.
+- Each FFI entry point should convert the inputs from unsafe types to safe ones
+  (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function,
+  and convert the results back to unsafe types if needed. Do not add extraneous
+  unsafe code to FFI entry points.
+- The FFI entry points should be as minimal as possible, and do as little
+  non-trivial work as necessary. All proper program logic should stay out of
+  the FFI wrappers and instead live in the internal safe Rust code.
+- Don't hide implementation logic in macros. Macro expansions count as part of
+  the FFI entry point body: an entry point must dispatch to a named
+  implementation function, and must not invoke macros that expand to program
+  logic or unsafe code.
+- Don't add calls to FFI entry points (`*_ffi` functions). These entry points
+  are only for use from C. When changing a non-FFI function's signature, update
+  all call sites to handle the new signature rather than changing some call
+  sites to call the FFI entry point that still has the old signature.
+
+Do not recommend editing tests or original C code to make validation pass. Do
+not recommend new unsafe or unsafe-adjacent implementation code, including raw
+pointer fields or arguments, int-to-pointer casts, or calls to unsafe FFI APIs.
+
+Dependency policy: a Rust crate may be recommended as a replacement for a
+dependency of the original C project (for example, a zlib crate where the C
+project vendored zlib, or an entropy crate replacing `arc4random`), with a
+one-line justification. Prefer well-known, actively maintained crates, such as
+those listed on https://blessed.rs/crates. Never recommend replacing the
+project under migration itself — in whole or in module-sized parts — with an
+existing crate.
+
+## The unsafe-code inventory
+
+Static analysis results are provided as JSON, one file per crate, in the
+directory named by the `FIND_UNSAFE2_JSON_DIR` environment variable (the
+parent's spawn message may give the concrete path). Each file contains:
+
+- `total_unsafe`: crate-wide count of unsafety findings, excluding FFI entry
+  points.
+- `fns`: a map from function name to a record with `filename`, `total_unsafe`,
+  `is_ffi_entry_point`, `is_unsafe_fn`, `is_mut_static`, `derefs_raw_ptr`,
+  `calls_unsafe`, and the maps `uses_static_mut` and `uses_union_field` (keyed
+  by the static or field used), plus the progress metrics `uses_foreign_fn`,
+  `casts_int_to_ptr`, and `sig_contains_raw_ptr`.
+- `types`: a map from type name to a record with `filename` and
+  `field_contains_raw_ptr`, a map from field name to raw-pointer count. A type
+  alias whose definition contains a raw pointer appears with the pseudo-field
+  `"type"`.
+
+The harness that later executes the plan assigns work targets using exactly
+these function, type, and field names. Cite symbols in your report using these
+exact names so the plan can be keyed to them.
+
+## Report format
+
+Keep the report under 1,500 words or 30 significant findings. For every
+finding, cite concrete files and symbols. Separate observed facts from
+inferences. Return:
+
+1. an evidence-backed inventory for your lens;
+2. semantic and compatibility constraints;
+3. recommended safe Rust mappings, as tables where possible:
+   - struct fields: `type.field` | current type | recommended safe type |
+     rationale / depends on;
+   - functions: function | problem | recommended change | depends on;
+4. dependencies, blockers, and risky edge cases; and
+5. a prioritized list of reasonably scoped refactoring units, grouping
+   same-shaped migrations into one unit.

--- a/crisp/agent/codex/strings_analyst.toml
+++ b/crisp/agent/codex/strings_analyst.toml
@@ -1,0 +1,27 @@
+name = "strings_analyst"
+description = "Read-only analyst for mapping C strings, byte buffers, paths, and text operations to safe Rust representations."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Before analyzing, read `.codex/safety_constraints.md` in full and obey it.
+
+Classify C string and character-buffer uses by ownership, mutability,
+termination, explicit length, capacity, encoding, embedded-NUL behavior, and
+whether the data is text, arbitrary bytes, or an operating-system path. Trace
+allocation and lifetime conventions across call sites and FFI boundaries. You
+own the choice of representation for textual and byte-string data, including
+how `str*`/`mem*` calls on such data map onto methods of the chosen type.
+
+Recommend precise Rust representations such as str, String, byte slices, Vec
+of bytes, CStr, CString, OsStr, OsString, Path, or PathBuf. Flag cases where
+UTF-8 conversion or CString would change accepted inputs. Identify reusable
+conversion helpers without moving program logic into FFI wrappers.
+
+Out of scope: non-string library calls such as allocation, file descriptors,
+I/O, and time (libc_analyst), and container structures that merely hold
+strings (collections_analyst).
+
+Do not modify files. Return only the structured, evidence-backed report
+requested by the shared constraints.
+"""

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -119,18 +119,49 @@ New signatures:
 '''
 
 AGENT_PLAN_PROMPT = '''
-Make a plan to refactor the Rust code in `{cargo_dir_path}` to be safe, without changing its behavior.  The goal is to make the code fully safe, including migrating to safe memory management (`Box`/`Vec`/`Rc`) and  safe pointer types (`&T`/`&[T]`) throughout.
-Write the plan to a file named `SAFETY_PLAN.md`.
+Write `SAFETY_PLAN.md`: a migration plan for refactoring the Rust code in `{cargo_dir_path}` to be fully safe without changing its behavior.  The goal state uses safe memory management (`Box`/`Vec`/`Rc`) and safe pointer types (`&T`/`&[T]`) throughout, with all remaining unsafety confined to FFI entry points.
 
-The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions.
+This is a planning-only step.  Do not modify, create, rename, or delete any source files; your only output is `SAFETY_PLAN.md` at the repository root.
 
-Implementation code may be freely refactored to improve safety. Here are some examples of useful changes to make:
-- Replace raw pointers with safe reference or smart pointer types, so that dereferences can be done safely.
-- Replace `static mut`s with non-`mut` and unions with enums so they can be accessed safely.
-- Eliminate calls to FFI imports and other unsafe functions. Try to replace these with suitable safe Rust operations, e.g. `printf` -> `println!`.
-- Remove the `unsafe` qualifier from functions that no longer need it, so that their callers can be made safe.
+# How the plan will be used
 
-For FFI entry points, the following rules apply (these rules must be copied verbatim into the plan and never changed or broken):
+The plan is executed incrementally by fresh agent instances that do not see this conversation.  Each instance reads `SAFETY_PLAN.md`, gets a small work budget, and is usually assigned one specific target -- a single struct field or a single function, chosen by an external harness from the unsafe-code inventory in `$FIND_UNSAFE2_JSON_DIR` -- though sometimes it is simply told to continue the plan.  Each instance updates the Status section before finishing.  The harness independently validates every step (build, tests, and an unsafe-code check) and injects the exact validation commands into every instance's instructions.
+
+Consequences for how you must write the plan:
+- It is a lookup document, not a narrative.  An agent assigned an arbitrary struct field or function must be able to find the cluster covering its target and read what to do.  Key every entry by the exact symbol names used in the inventory JSON, so targets can be found by grep.
+- Every line is re-read on every step.  Keep the plan compact: prefer tables over prose, don't restate what the code already shows, and aim for well under 400 lines even for large codebases.
+- Do not include any build, test, lint, or verification commands, and no command-based acceptance gates; the harness supplies all validation.  State done-criteria in semantic terms tied to the inventory, e.g. "no field of struct X is a raw pointer" or "no function in this cluster is an `unsafe fn`".
+- Do not spell out full speculative Rust signatures; name the target types and ownership model and let the executing agent work out details against the code it sees.
+
+# Analysis phase
+
+Use the following read-only custom sub-agents, one per independent analysis lens:
+- `ffi_abi_analyst`: exported functions and data, ABI compatibility constraints.
+- `ownership_analyst`: allocation, ownership, aliasing, lifetimes, `static mut` globals, and unions.
+- `collections_analyst`: custom containers, plus internal function-pointer tables and dispatch.
+- `strings_analyst`: strings, byte buffers, text, and paths.
+- `libc_analyst`: C, POSIX, and platform library calls.
+- `macro_analyst`: oversized or repetitive translated functions caused by C macro expansion.
+
+Spawn exactly one fresh instance of each named agent with `fork_turns="none"`.  Each agent already carries its lens instructions and the shared constraints (`.codex/safety_constraints.md`); keep spawn messages short, containing only the run-specific facts:
+- the Rust project path: `{cargo_dir_path}`;
+- the location of the unsafe-code inventory: the concrete directory path from `$FIND_UNSAFE2_JSON_DIR`; and
+- whether the original C sources are present in the workspace, and where.
+
+Wait for all agents to finish.  If an agent fails or returns an unusably thin report, note the gap and proceed with the remaining reports.  Reconcile overlaps, dependencies, and disagreements between the reports rather than concatenating them.  Cross-check coverage against the inventory: every file with unsafe findings must be covered by exactly one cluster in the plan.  Then have only the parent agent write `SAFETY_PLAN.md`; do not delegate the writing.
+
+# Required plan structure
+
+`SAFETY_PLAN.md` must contain exactly these four sections:
+
+1. `## FFI entry point rules` -- the rules block below, copied verbatim and marked as immutable.
+2. `## Conventions` -- the crate-wide decisions every step must follow: standard type mappings (e.g. which pointer-plus-length idioms become `&[u8]`, when owned text is `String` vs `Vec<u8>`), the error-handling model, callback handling, and the standard moves: raw pointers -> references or smart pointers; `static mut` -> immutable `static`/`const`, `OnceLock`, or atomics; unions -> enums or explicit safe fields; unsafe FFI imports -> safe std equivalents (e.g. `printf` -> `println!`); custom containers -> std collections where semantics allow; remove `unsafe` qualifiers from functions that no longer need them.  Also state the dependency policy: a Rust crate may replace a dependency of the original C project (with one line of justification), but must never replace the project under migration itself, in whole or in module-sized parts.
+3. `## Cluster guide` -- the codebase partitioned into dependency-ordered clusters (a module or data-structure family plus the functions around it).  For each cluster: the files it covers; prerequisites (clusters or conventions that must land first); a table mapping each struct field that contains raw pointers to its recommended safe type with a one-line rationale; the key functions and how they change; pitfalls and risky edge cases; and semantic done-criteria.  Group same-shaped migrations into a single unit: if migrating `f` to `String` implies the same change in `g`, plan them together.
+4. `## Status` -- the working log.  Initialize it with "no work started" plus the recommended first units; executing instances append what they did, what is in flight, and dead ends to avoid.
+
+# FFI entry point rules (copy verbatim into the plan)
+
+The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions. Implementation code may be freely refactored to improve safety. For FFI entry points, the following rules apply and must never be changed or broken:
 - You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
 - For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
 - Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
@@ -138,14 +169,10 @@ For FFI entry points, the following rules apply (these rules must be copied verb
 - The FFI entry points should be as minimal as possible, and do as little
   non-trivial work as necessary. All proper program logic should stay out of
   the FFI wrappers and instead live in the internal safe Rust code.
-
-{after_refactoring_instruction}
-
-Your changes must not introduce new unsafe code within implementation functions. You can check your work using this command:
-```sh
-cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
-```
-This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
+- Don't hide implementation logic in macros. Macro expansions count as part of
+  the FFI entry point body: an entry point must dispatch to a named
+  implementation function, and must not invoke macros that expand to program
+  logic or unsafe code.
 '''
 
 AGENT_SAFETY_PROMPT = '''
@@ -1399,12 +1426,6 @@ class Workflow:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
 
-        if cfg.test_command is not None:
-            after_refactoring_instruction = AGENT_AFTER_REFACTORING_RUN_TESTS \
-                    .format(test_cmd = cfg.test_command)
-        else:
-            after_refactoring_instruction = AGENT_AFTER_REFACTORING_BUILD
-
         extra_code = [
             self.find_unsafe2_json(n_code),
         ]
@@ -1418,14 +1439,12 @@ class Workflow:
             # TODO: un-break that mode somehow (without hiding the C code).
             extra_code.append(n_test_code)
 
-        prompt = AGENT_PLAN_PROMPT.format(
-            cargo_dir_path = cargo_dir,
-            after_refactoring_instruction = after_refactoring_instruction,
-        )
+        prompt = AGENT_PLAN_PROMPT.format(cargo_dir_path = cargo_dir)
         return agent.run_rewrite(cfg, mvir, prompt, self.cfg.models.agent_plan, n_code,
             extra_code = extra_code,
             planning_files = None,
             codex_login=self.codex_login,
+            codex_agents=agent.PLANNING_CODEX_AGENTS,
             clean_cmds = [
                 ['cargo', 'clean', '--manifest-path', os.path.join(cargo_dir, 'Cargo.toml')],
             ],

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -135,6 +135,9 @@ For FFI entry points, the following rules apply (these rules must be copied verb
 - For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
 - Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
 - Don't add calls to FFI entry points (`*_ffi` functions).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
+- The FFI entry points should be as minimal as possible, and do as little
+  non-trivial work as necessary. All proper program logic should stay out of
+  the FFI wrappers and instead live in the internal safe Rust code.
 
 {after_refactoring_instruction}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,11 @@ gepa = [
 [project.scripts]
 crisp = "crisp.__main__:main"
 
-[tool.setuptools]
-packages = ["crisp"]
+[tool.setuptools.packages.find]
+include = ["crisp*"]
+
+[tool.setuptools.package-data]
+"crisp.agent" = ["codex/*.md", "codex/*.toml"]
 
 [tool.uv]
 package = true

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,85 @@
+import tomllib
+import unittest
+from unittest.mock import patch
+
+from crisp import agent
+from crisp.error import CrispError
+from crisp.workflow import AGENT_PLAN_PROMPT
+
+
+class CodexAgentProfilesTest(unittest.TestCase):
+    def test_planning_profiles_use_current_codex_schema(self):
+        expected_models = {
+            'ffi_abi_analyst': ('gpt-5.6-sol', 'high'),
+            'ownership_analyst': ('gpt-5.6-sol', 'xhigh'),
+            'collections_analyst': ('gpt-5.6-terra', 'high'),
+            'strings_analyst': ('gpt-5.6-terra', 'medium'),
+            'libc_analyst': ('gpt-5.6-terra', 'medium'),
+            'macro_analyst': ('gpt-5.6-terra', 'medium'),
+        }
+        profiles = {
+            path.stem: tomllib.loads(path.read_text())
+            for path in agent._CODEX_ASSET_DIR.glob('*.toml')
+        }
+
+        self.assertEqual(set(profiles), set(agent.PLANNING_CODEX_AGENTS))
+        for name, profile in profiles.items():
+            self.assertEqual(profile['name'], name)
+            self.assertTrue(profile['description'])
+            self.assertTrue(profile['developer_instructions'])
+            self.assertEqual(profile['sandbox_mode'], 'read-only')
+            self.assertEqual(
+                (profile['model'], profile['model_reasoning_effort']),
+                expected_models[name],
+            )
+            self.assertIn(
+                '.codex/safety_constraints.md',
+                profile['developer_instructions'],
+            )
+
+    def test_planning_profiles_are_injected_under_codex_home(self):
+        written = {}
+
+        def capture(_sb, _mvir, rel_path, body):
+            written[rel_path] = body
+
+        with patch.object(agent, '_checkout_bytes', side_effect=capture):
+            agent._inject_codex_agents(
+                object(), object(), agent.PLANNING_CODEX_AGENTS)
+
+        self.assertIn('.codex/safety_constraints.md', written)
+        self.assertEqual(
+            {
+                path.removeprefix('.codex/agents/').removesuffix('.toml')
+                for path in written
+                if path.startswith('.codex/agents/')
+            },
+            set(agent.PLANNING_CODEX_AGENTS),
+        )
+
+    def test_unknown_profile_is_rejected(self):
+        with self.assertRaisesRegex(CrispError, 'unknown Codex agent profile'):
+            agent._inject_codex_agents(object(), object(), ('missing',))
+
+    def test_planning_prompt_orchestrates_all_profiles(self):
+        for name in agent.PLANNING_CODEX_AGENTS:
+            self.assertIn(f'`{name}`', AGENT_PLAN_PROMPT)
+        self.assertIn('fork_turns="none"', AGENT_PLAN_PROMPT)
+        self.assertIn('Wait for all agents', AGENT_PLAN_PROMPT)
+        self.assertIn('only the parent agent write', AGENT_PLAN_PROMPT)
+        self.assertIn('`{cargo_dir_path}`', AGENT_PLAN_PROMPT)
+        self.assertIn('$FIND_UNSAFE2_JSON_DIR', AGENT_PLAN_PROMPT)
+        self.assertIn('.codex/safety_constraints.md', AGENT_PLAN_PROMPT)
+        self.assertIn('Do not modify, create, rename, or delete',
+                      AGENT_PLAN_PROMPT)
+        # The required plan sections.
+        self.assertIn('## FFI entry point rules', AGENT_PLAN_PROMPT)
+        self.assertIn('## Conventions', AGENT_PLAN_PROMPT)
+        self.assertIn('## Cluster guide', AGENT_PLAN_PROMPT)
+        self.assertIn('## Status', AGENT_PLAN_PROMPT)
+        # The plan must not carry verification commands; the harness does.
+        self.assertIn('the harness supplies all validation', AGENT_PLAN_PROMPT)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Extend #152 which adds planning step with more specific planning and custom subagents.

The generated plans are linear phase narratives, but the safety loop executes them through fresh agent instances, each handed a single struct field or function picked from the find-unsafe2 inventory plus a small work budget. The plan's shape didn't match how it is consumed.

- `AGENT_PLAN_PROMPT` now explains that execution model to the planner and mandates a fixed plan structure: verbatim FFI rules, crate-wide conventions, a dependency-ordered cluster guide keyed by the exact inventory symbol names (an assigned target greps straight to its row), and a status log for iterations to update.
- Plans no longer carry verification commands; the harness injects the real ones every step. Earlier plans invented `nm`/`cmp`/`cargo fmt` gates that can burn executor budget on non-goals.
- Spawn messages carry only run-specific facts. Lens instructions, the unsafe-inventory JSON schema, and the dependency policy (a crate may replace a dependency of the C project, never the project under migration itself) live in the agent profiles and shared `safety_constraints.md`.
- Analyst scopes are now explicit and non-overlapping: `ownership_analyst` also owns `static mut` and unions, `collections_analyst` owns internal function-pointer dispatch, and `macro_analyst` triages for the measurable symptom of macro expansion (oversized or repetitive translated functions vs. the original C) and exits early when there is none.
