### PR TITLE
Support selecting the docker image by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ uv sync
 docker build --target tractor-crisp-user --tag tractor-crisp-user .
 ```
 
+By default, CRISP uses the image named `tractor-crisp-user`. To use a
+different image, set `CRISP_DOCKER_IMAGE` when running CRISP:
+
+```sh
+docker build --target tractor-crisp-user --tag my-tractor-crisp-user .
+CRISP_DOCKER_IMAGE=my-tractor-crisp-user crisp main
+```
+
 ## Configuring CRISP
 
 Set up `crisp.toml` as above.

--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -11,6 +11,10 @@ from ..mvir import FileNode, TreeNode
 from ..util import ChunkPrinter
 
 
+DEFAULT_DOCKER_IMAGE = 'tractor-crisp-user'
+DOCKER_IMAGE_ENV_VAR = 'CRISP_DOCKER_IMAGE'
+
+
 class WorkContainer:
     """
     Helper for managing a Docker/Podman container for building and running user
@@ -24,10 +28,11 @@ class WorkContainer:
     def __init__(self, mvir):
         self.mvir = mvir
         self.client = docker.from_env()
+        image_name = os.environ.get(DOCKER_IMAGE_ENV_VAR, DEFAULT_DOCKER_IMAGE)
         try:
-            self.image = self.client.images.get('tractor-crisp-user')
-        except:
-            print('error getting image `tractor-crisp-user` - you may need to build it first')
+            self.image = self.client.images.get(image_name)
+        except Exception:
+            print(f'error getting image `{image_name}` - you may need to build it first')
             raise
         self.container = None
 

--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -31,7 +31,7 @@ class WorkContainer:
         image_name = os.environ.get(DOCKER_IMAGE_ENV_VAR, DEFAULT_DOCKER_IMAGE)
         try:
             self.image = self.client.images.get(image_name)
-        except Exception:
+        except:
             print(f'error getting image `{image_name}` - you may need to build it first')
             raise
         self.container = None


### PR DESCRIPTION
While running CRISP on cJSON, I ran into an issue related to the tractor-crisp-user docker image that caused my run to break. Docker images are global per machine, and I'm running CRISP on a machine that other people are using for CRISP runs. When I build a docker image with the tractor-crisp-user tag, that image is global and other people running CRISP on the same machine will use that same image. That also means that if someone else rebuilds the docker image they may change the image out from under my run while it's in progress, which can lead to conflicts or cause inconsistent results.

Currently CRISP is hard coded to use the image tagged as tractor-crisp-user. This PR adds the ability to change the selected image with a `CRISP_DOCKER_IMAGE` env var. We can also add a CLI flag to do the same thing, but the env var was sufficient for my purposes.