### PR TITLE
Add apply_patch symlink for Codex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,21 @@ RUN mkdir /opt/codex-cli \
     && wget --quiet "$codex_url" \
     && tar -xzf "$(basename "$codex_url")" \
     && ln -s "$PWD/codex-x86_64-unknown-linux-musl" /usr/local/bin/codex \
+    && ln -s "$PWD/codex-x86_64-unknown-linux-musl" /usr/local/bin/apply_patch \
     && rm "$(basename "$codex_url")"
+
+# Verify that the Codex file-editing helper is available and functional.
+RUN workdir="$(mktemp -d)" \
+    && cd "$workdir" \
+    && printf '%s\n' \
+        '*** Begin Patch' \
+        '*** Add File: probe.txt' \
+        '+working' \
+        '*** End Patch' \
+        | apply_patch \
+    && test "$(cat probe.txt)" = working \
+    && cd / \
+    && rm -rf "$workdir"
 
 # Append the location of the Rust binaries to PATH
 # since `sh -l` overwrites that variable with the value


### PR DESCRIPTION
In working on https://github.com/GaloisInc/Tractor-Crisp/pull/159 I was looking over what Git operations the agent tries to perform, and I was seeing the agent often trying (and sometimes failing) to use `git apply` in order to edit files. This seemed weird to me because I would think the agent could edit the files directly. Turns out, Codex has an `apply_patch` utility that it normally tries to use, but we weren't setting that up in the docker container. This meant that Codex fell back to using `git apply` and other hacks to modify files.

`apply_patch` is actually just a symlink to the main `codex` binary, so this PR adds that symlink to our docker images and includes a little test to verify that the utility does what we expect (which should help us catch future incompatibility if things change in the future).