### PR TITLE
Handle the case where multiple nodes have the same code

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -284,17 +284,27 @@ def prior_agent_plans(mvir, n_code) -> TreeNode | None:
         if ie.kind == CodexAgentOpNode.KIND and ie.key == 'new_code'
     ]
 
-    match matches:
-        case [ie]:
-            op_node = mvir.node(ie.node_id)
+    if not matches:
+        return None
+
+    if len(matches) == 1:
+        op_node = mvir.node(matches[0].node_id)
+        return mvir.node(op_node.planning_files)
+
+    # An agent step can update SAFETY_PLAN.md without changing any source
+    # files.  Several successful steps can therefore produce the same code
+    # node with different planning nodes.  The reverse index is not ordered,
+    # so use the timestamped operation reflog to find the latest producer.
+    match_ids = {ie.node_id for ie in matches}
+    for entry in reversed(mvir.tag_reflog('op_history')):
+        if entry.node_id in match_ids:
+            op_node = mvir.node(entry.node_id)
             return mvir.node(op_node.planning_files)
-        case []:
-            return None
-        case _:
-            raise CrispError(
-                f'multiple Codex agent ops produced code node {n_code.node_id()}: '
-                + ', '.join(str(ie.node_id) for ie in matches)
-            )
+
+    raise CrispError(
+        f'no op_history entry found for Codex producers of {n_code.node_id()}: '
+        + ', '.join(str(ie.node_id) for ie in matches)
+    )
 
 
 @dataclass(frozen = True)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -284,25 +284,25 @@ def prior_agent_plans(mvir, n_code) -> TreeNode | None:
         if ie.kind == CodexAgentOpNode.KIND and ie.key == 'new_code'
     ]
 
-    if not matches:
-        return None
-
-    if len(matches) == 1:
-        op_node = mvir.node(matches[0].node_id)
-        return mvir.node(op_node.planning_files)
-
-    # Multiple ops can produce the same tree (planning step, no-op safety
-    # steps); take the most recent one from the `op_history` reflog.
-    match_ids = {ie.node_id for ie in matches}
-    for entry in reversed(mvir.tag_reflog('op_history')):
-        if entry.node_id in match_ids:
-            op_node = mvir.node(entry.node_id)
+    match matches:
+        case [ie]:
+            op_node = mvir.node(ie.node_id)
             return mvir.node(op_node.planning_files)
+        case []:
+            return None
+        case _:
+            # Multiple ops can produce the same tree (planning step, no-op safety
+            # steps); take the most recent one from the `op_history` reflog.
+            match_ids = {ie.node_id for ie in matches}
+            for entry in reversed(mvir.tag_reflog('op_history')):
+                if entry.node_id in match_ids:
+                    op_node = mvir.node(entry.node_id)
+                    return mvir.node(op_node.planning_files)
 
-    raise CrispError(
-        f'no op_history entry found for Codex producers of {n_code.node_id()}: '
-        + ', '.join(str(ie.node_id) for ie in matches)
-    )
+            raise CrispError(
+                f'no op_history entry found for Codex producers of {n_code.node_id()}: '
+                + ', '.join(str(ie.node_id) for ie in matches)
+            )
 
 
 @dataclass(frozen = True)

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -291,10 +291,8 @@ def prior_agent_plans(mvir, n_code) -> TreeNode | None:
         op_node = mvir.node(matches[0].node_id)
         return mvir.node(op_node.planning_files)
 
-    # An agent step can update SAFETY_PLAN.md without changing any source
-    # files.  Several successful steps can therefore produce the same code
-    # node with different planning nodes.  The reverse index is not ordered,
-    # so use the timestamped operation reflog to find the latest producer.
+    # Multiple ops can produce the same tree (planning step, no-op safety
+    # steps); take the most recent one from the `op_history` reflog.
     match_ids = {ie.node_id for ie in matches}
     for entry in reversed(mvir.tag_reflog('op_history')):
         if entry.node_id in match_ids:


### PR DESCRIPTION
While running tests on cJSON, I hit an error that caused `crisp safety-loop` to fail to start:

<details><summary>Log output showing the crash</summary>

```txt
code size = 3102
default limits = FuelLimits(safety_tries=45, max_consecutive_failures=5, safety_tries_per_target=3)
limits = FuelLimits(safety_tries=100, max_consecutive_failures=5, safety_tries_per_target=3)
Traceback (most recent call last):
  File "/home/legare/cJSON_lib/Tractor-Crisp/.venv/bin/crisp", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/legare/cJSON_lib/Tractor-Crisp/crisp/__main__.py", line 752, in main
    do_safety_loop(args, cfg)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/legare/cJSON_lib/Tractor-Crisp/crisp/__main__.py", line 561, in do_safety_loop
    safety_loop_common(args, cfg, mvir, w, n_code, n_c_code)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/legare/cJSON_lib/Tractor-Crisp/crisp/__main__.py", line 374, in safety_loop_common
    n_plans = prior_agent_plans(mvir, n_code) or TreeNode.new(mvir, files={})
              ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/legare/cJSON_lib/Tractor-Crisp/crisp/__main__.py", line 294, in prior_agent_plans
    raise CrispError(
    ...<2 lines>...
    )
crisp.error.CrispError: multiple Codex agent ops produced code node 43cf044a94992800291a8455ae20d538944a054fe9606856ec73f1b372ccc3cc: 2bc06877123e07cc5f5eca92087681fb9a99024930b3867331795c708455a25b, 1dcbf4f9f361edae04b7ad51b91c7a84afa404566e00ca88a6f4d6b81fb85466, 073165d1242a3134bdb5a930b2e0fd3266c20e42dd6f12a3024321fefd0db180, 8598bd1975c171715bbe9aa626932580ce3421ecc72ca05019f5738939a9933d, 4a347686a89d71c280d5703769abfbdb3bbb129cd0a932de5789dd9322533b43
```
</details>

The issue was that the last turn of the loop from the previous `crisp safety-loop` run had modified `SAFETY_PLAN.md`, but had not modified the Rust code. This meant that there were multiple nodes that produced the same code, which caused CRISP to fail to select the appropriate starting node for the new safety run. This only happens if you start a new `crisp safety-loop` after an edit that only touches `SAFETY_PLAN.md`, within a CRISP run we don't hit this issue because the safety loop already carries the appropriate code node to the next turn of the loop.

This PR adds a bit of extra logic to grab the latest code node (by timestamp, I think).