### PR TITLE
agent: git-ignore .codex/ in the rewrite sandbox repo

### DIFF
--- a/crisp/agent.py
+++ b/crisp/agent.py
@@ -141,6 +141,8 @@ def run_rewrite(
         gitignore_lines = [
             '# Cargo build output',
             'target/',
+            '# Codex home; may contain auth.json',
+            '.codex/',
         ]
         if find_unsafe2_json_dir is not None:
             gitignore_lines.extend([


### PR DESCRIPTION
`run_rewrite`'s sandbox `.gitignore` doesn't cover `.codex/`. The baseline commit predates `.codex/` so it stays clean, but the agent later sees untracked noise in `git status`, and an agent-side `git add -A && git commit` would bake `auth.json` into the throwaway repo's history. MVIR capture is unaffected.