### PR TITLE
workflow: add review gate for FFI entry point edits

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -29,7 +29,8 @@ from .sandbox import run_sandbox
 from .work_dir import lock_work_dir, set_keep_work_dir
 from .workflow import (
     Workflow, FuelCounter, OutOfFuelError, AgentTargetField, AgentTargetFunction,
-    AgentTargetOther, AGENT_FFI_REJECTED_PROMPT,
+    AgentTargetOther, AGENT_FFI_REJECTED_PROMPT, AGENT_FFI_SEEN_FINDINGS_PROMPT,
+    merge_ffi_finding_titles,
 )
 
 
@@ -393,6 +394,9 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
     # Report from the most recent FFI review rejection since the last accepted
     # step; fed back into the next attempt's prompt.
     ffi_feedback = None
+    # Titles of FFI review findings seen this run.  Unlike `ffi_feedback`,
+    # never cleared by an accepted step.
+    ffi_seen_findings = []
     n_plans = prior_agent_plans(mvir, n_code)
     if not n_plans:
         if 'agent' in args.llm_mode:
@@ -429,10 +433,14 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
         try:
             ffi_report = None
-            ffi_suffix = None
+            ffi_parts = []
+            if ffi_seen_findings:
+                ffi_parts.append(AGENT_FFI_SEEN_FINDINGS_PROMPT.format(
+                    findings = '\n'.join(f'- {t}' for t in ffi_seen_findings)))
             if ffi_feedback is not None:
-                ffi_suffix = AGENT_FFI_REJECTED_PROMPT.format(
-                    report = ffi_feedback)
+                ffi_parts.append(AGENT_FFI_REJECTED_PROMPT.format(
+                    report = ffi_feedback))
+            ffi_suffix = '\n\n'.join(ffi_parts) if ffi_parts else None
 
             match args.llm_mode:
                 case 'agent':
@@ -508,6 +516,8 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 ffi_feedback = None
             elif ffi_report is not None:
                 ffi_feedback = ffi_report
+                ffi_seen_findings = merge_ffi_finding_titles(
+                    ffi_seen_findings, ffi_report)
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')

--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -29,7 +29,7 @@ from .sandbox import run_sandbox
 from .work_dir import lock_work_dir, set_keep_work_dir
 from .workflow import (
     Workflow, FuelCounter, OutOfFuelError, AgentTargetField, AgentTargetFunction,
-    AgentTargetOther,
+    AgentTargetOther, AGENT_FFI_REJECTED_PROMPT,
 )
 
 
@@ -390,6 +390,9 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
 
     best_unsafe_count = None
     consecutive_failures = 0
+    # Report from the most recent FFI review rejection since the last accepted
+    # step; fed back into the next attempt's prompt.
+    ffi_feedback = None
     n_plans = prior_agent_plans(mvir, n_code)
     if not n_plans:
         if 'agent' in args.llm_mode:
@@ -425,6 +428,12 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
         prev_fuel = cur_fuel
 
         try:
+            ffi_report = None
+            ffi_suffix = None
+            if ffi_feedback is not None:
+                ffi_suffix = AGENT_FFI_REJECTED_PROMPT.format(
+                    report = ffi_feedback)
+
             match args.llm_mode:
                 case 'agent':
                     match consecutive_failures:
@@ -461,14 +470,19 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                                 'or this run will be terminated.'
                             )
 
-                    n_new_code, n_new_plans = w.do_safety_step_agent(
+                    if ffi_suffix is not None:
+                        suffix = ffi_suffix if suffix is None \
+                            else f'{suffix}\n\n{ffi_suffix}'
+
+                    n_new_code, n_new_plans, ffi_report = w.do_safety_step_agent(
                         n_code, n_c_code, n_plans,
                         prompt_suffix = suffix)
 
                 case 'agent_rand_target':
                     target_goal = pick_target.current_target_goal(w, n_code)
-                    n_new_code, n_new_plans = w.do_safety_step_agent(
+                    n_new_code, n_new_plans, ffi_report = w.do_safety_step_agent(
                         n_code, n_c_code, n_plans,
+                        prompt_suffix = ffi_suffix,
                         target_goal = target_goal)
 
                 case 'agent_sim_no_tests':
@@ -491,6 +505,9 @@ def safety_loop_common(args, cfg, mvir, w, n_code, n_c_code):
                 w.accept(n_new_code, ('main', 'safety', cur_fuel))
                 n_code = n_new_code
                 n_plans = n_new_plans
+                ffi_feedback = None
+            elif ffi_report is not None:
+                ffi_feedback = ffi_report
 
         except CrispError as e:
             print(f'{args.llm_mode} safety attempt {cur_fuel} failed: {e}')

--- a/crisp/agent/__init__.py
+++ b/crisp/agent/__init__.py
@@ -38,6 +38,34 @@ WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
     "by commands run by the agent; please make sure " \
     "to set limits on its usage.\033[0m"
 
+# Turn the sandbox contents into the baseline commit of a small local repo
+GIT_BASELINE_CMD = (
+    'git init -q && git add --all && '
+    'git -c user.name=CRISP -c user.email=crisp@localhost '
+    'commit --quiet -m "CRISP sandbox baseline"')
+
+
+def _normalize_run_args(
+    extra_code: TreeNode | list[TreeNode],
+    env: dict | None,
+) -> tuple[list[TreeNode], dict]:
+    """Shared argument normalization for the codex entry points below."""
+    if 'CRISP_API_KEY' in os.environ:
+        print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
+    if isinstance(extra_code, TreeNode):
+        extra_code = [extra_code]
+    return extra_code, {} if env is None else env
+
+
+def _setup_codex_home(sb, env: dict, codex_login: bool) -> str:
+    """Point CODEX_HOME at the sandbox `.codex/` dir; inject auth if requested."""
+    if codex_login:
+        print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
+        _inject_codex_auth(sb)
+    codex_dir = sb.join('.codex')
+    env.setdefault('CODEX_HOME', codex_dir)
+    return codex_dir
+
 
 def _snapshot_to_family_alias(model: str) -> str:
     """
@@ -173,14 +201,7 @@ def run_rewrite(
     find_unsafe2_json_dir: str | None = None,
     codex_agents: Sequence[str] = (),
 ) -> tuple[TreeNode, TreeNode]:
-    if 'CRISP_API_KEY' in os.environ:
-        print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
-
-    if isinstance(extra_code, TreeNode):
-        extra_code = [extra_code]
-
-    if env is None:
-        env = {}
+    extra_code, env = _normalize_run_args(extra_code, env)
 
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(input_code)
@@ -211,20 +232,12 @@ def run_rewrite(
         gitignore_file = FileNode.new(
             mvir, '\n'.join(gitignore_lines) + '\n')
         sb.checkout_file('.gitignore', gitignore_file)
-        init_git_repo = (
-            'git init -q && git add --all && '
-            'git -c user.name=CRISP -c user.email=crisp@localhost '
-            'commit --quiet -m "CRISP sandbox baseline"')
-        exit_code, logs = sb.run(init_git_repo, cwd='.', shell=True, stream=True)
+        exit_code, logs = sb.run(GIT_BASELINE_CMD, cwd='.', shell=True, stream=True)
 
         if exit_code == 0:
             _inject_codex_agents(sb, mvir, codex_agents)
 
-            if codex_login:
-                print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
-                _inject_codex_auth(sb)
-
-            codex_dir = sb.join(".codex")
+            codex_dir = _setup_codex_home(sb, env, codex_login)
             mkdir_codex = ['mkdir', '-p', codex_dir]
 
             codex_cmd = _codex_command(cfg, 'exec', [
@@ -235,8 +248,6 @@ def run_rewrite(
             print(codex_cmd)
             all_cmds = [mkdir_codex, codex_cmd] + clean_cmds
 
-            if 'CODEX_HOME' not in env:
-                env['CODEX_HOME'] = codex_dir
             if find_unsafe2_json_dir is not None:
                 env['FIND_UNSAFE2_JSON_DIR'] = sb.join(find_unsafe2_json_dir)
 
@@ -363,14 +374,7 @@ def run_review(
                 return True
         return False
 
-    if 'CRISP_API_KEY' in os.environ:
-        print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
-
-    if isinstance(extra_code, TreeNode):
-        extra_code = [extra_code]
-
-    if env is None:
-        env = {}
+    extra_code, env = _normalize_run_args(extra_code, env)
 
     with run_sandbox(cfg, mvir) as sb:
         sb.checkout(old_code)
@@ -379,27 +383,20 @@ def run_review(
         # Keep sandbox-only files out of the reviewed diff.
         _checkout_bytes(sb, mvir, '.gitignore', b'.codex/\ntarget/\n')
 
-        if codex_login:
-            print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
-            _inject_codex_auth(sb)
-
-        codex_dir = sb.join('.codex')
+        codex_dir = _setup_codex_home(sb, env, codex_login)
         last_message_path = sb.join('.codex/last_message.txt')
 
-        setup_cmds = [
+        setup_cmds: list[str | list[str]] = [
             ['mkdir', '-p', codex_dir],
-            ['git', 'init', '-q'],
-            ['git', 'add', '-A'],
-            ['git', '-c', 'user.name=crisp', '-c', 'user.email=crisp@localhost',
-                'commit', '-qm', 'baseline'],
+            GIT_BASELINE_CMD,
         ]
         deleted_files = [path for path in old_code.files if path not in new_code.files]
         if deleted_files:
             setup_cmds.append(['rm', '-f'] + deleted_files)
         for cmd in setup_cmds:
-            exit_code, logs = sb.run(cmd, cwd=cwd, env=env)
+            exit_code, logs = sb.run(cmd, cwd=cwd, shell=isinstance(cmd, str), env=env)
             if exit_code != 0:
-                raise CrispError(f'{cmd[0]} failed: exit code {exit_code}: {logs!r}')
+                raise CrispError(f'{cmd!r} failed: exit code {exit_code}: {logs!r}')
         sb.checkout(new_code)
 
         codex_cmd = _codex_command(cfg, 'exec', [
@@ -413,9 +410,6 @@ def run_review(
             prompt,
         ], codex_login=codex_login, model=model)
         print(codex_cmd)
-
-        if 'CODEX_HOME' not in env:
-            env['CODEX_HOME'] = codex_dir
 
         exit_code, logs = sb.run(codex_cmd, cwd=cwd, stream=True, env=env)
         if exit_code != 0:

--- a/crisp/agent/__init__.py
+++ b/crisp/agent/__init__.py
@@ -2,6 +2,7 @@
 Rewrite operations using AI agent tools, such as codex-cli
 """
 
+import json
 import os
 import re
 from pathlib import Path
@@ -30,6 +31,12 @@ PLANNING_CODEX_AGENTS = (
 )
 
 _SNAPSHOT_SUFFIX = re.compile(r"^(?P<alias>.+)-\d{4}-\d{2}-\d{2}$")
+
+# Print the warning in red so it stands out
+WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
+    "the sandbox and could theoretically be leaked " \
+    "by commands run by the agent; please make sure " \
+    "to set limits on its usage.\033[0m"
 
 
 def _snapshot_to_family_alias(model: str) -> str:
@@ -166,13 +173,6 @@ def run_rewrite(
     find_unsafe2_json_dir: str | None = None,
     codex_agents: Sequence[str] = (),
 ) -> tuple[TreeNode, TreeNode]:
-    # Print the warning in red so it stands out
-    WARNING_TEMPLATE = "\033[31mwarning: {} is being copied into " \
-        "the sandbox and could theoretically be leaked " \
-        "by commands run by the agent; please make sure " \
-        "to set limits on its usage.\033[0m"
-
-
     if 'CRISP_API_KEY' in os.environ:
         print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
 
@@ -312,3 +312,120 @@ def run_rewrite(
             f'agent invocation failed: exit code {exit_code}', n_op)
 
     return (output_code, output_plans)
+
+
+def run_review(
+    cfg: Config,
+    mvir: MVIR,
+    prompt: str,
+    model: str,
+    old_code: TreeNode,
+    new_code: TreeNode,
+    extra_code: TreeNode | list[TreeNode] = [],
+    cwd: str = '.',
+    codex_login: bool = False,
+    env: dict | None = None,
+) -> tuple[str, bytes, bool]:
+    """
+    Run `codex exec review` over the change from `old_code` to `new_code` and
+    return the reviewer's final message, the full log output, and whether the
+    reviewer successfully ran at least one command (evidence that it actually
+    inspected the change rather than answering blind).
+
+    `codex exec review` is used rather than a plain `codex exec` prompt
+    because review mode reports findings in a fixed, machine-parseable format
+    (it overrides any output convention requested in the prompt).  Codex's own
+    sandbox is bypassed (it cannot start inside the CRISP sandbox).
+
+    Review mode can only review a git diff.  The review runs in its own
+    fresh sandbox (the rewrite sandbox and its repo are gone by now, and
+    `.git/` is never committed to MVIR), so the change is staged as
+    uncommitted edits on a baseline commit in a throwaway repo built from
+    the MVIR nodes; nothing is committed back to MVIR.  Codex rejects 
+    `--uncommitted` when custom review instructions are given, so `prompt`
+    itself must direct the reviewer at the uncommitted changes.
+    """
+    def _review_ran_commands(logs: bytes) -> bool:
+        """True iff the codex `--json` event stream in `logs` shows at
+           least one successfully executed command."""
+        for line in logs.splitlines():
+            try:
+                ev = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(ev, dict):
+                continue
+            item = ev.get('item')
+            if (ev.get('type') == 'item.completed'
+                    and isinstance(item, dict)
+                    and item.get('type') == 'command_execution'
+                    and item.get('exit_code') == 0):
+                return True
+        return False
+
+    if 'CRISP_API_KEY' in os.environ:
+        print(WARNING_TEMPLATE.format('CRISP_API_KEY'))
+
+    if isinstance(extra_code, TreeNode):
+        extra_code = [extra_code]
+
+    if env is None:
+        env = {}
+
+    with run_sandbox(cfg, mvir) as sb:
+        sb.checkout(old_code)
+        for n in extra_code:
+            sb.checkout(n)
+        # Keep sandbox-only files out of the reviewed diff.
+        _checkout_bytes(sb, mvir, '.gitignore', b'.codex/\ntarget/\n')
+
+        if codex_login:
+            print(WARNING_TEMPLATE.format('codex\'s login session (`auth.json`)'))
+            _inject_codex_auth(sb)
+
+        codex_dir = sb.join('.codex')
+        last_message_path = sb.join('.codex/last_message.txt')
+
+        setup_cmds = [
+            ['mkdir', '-p', codex_dir],
+            ['git', 'init', '-q'],
+            ['git', 'add', '-A'],
+            ['git', '-c', 'user.name=crisp', '-c', 'user.email=crisp@localhost',
+                'commit', '-qm', 'baseline'],
+        ]
+        deleted_files = [path for path in old_code.files if path not in new_code.files]
+        if deleted_files:
+            setup_cmds.append(['rm', '-f'] + deleted_files)
+        for cmd in setup_cmds:
+            exit_code, logs = sb.run(cmd, cwd=cwd, env=env)
+            if exit_code != 0:
+                raise CrispError(f'{cmd[0]} failed: exit code {exit_code}: {logs!r}')
+        sb.checkout(new_code)
+
+        codex_cmd = _codex_command(cfg, 'exec', [
+            'review',
+            # Codex's own sandbox (bubblewrap) cannot start inside the CRISP
+            # sandbox; the CRISP sandbox is the containment layer.
+            '--dangerously-bypass-approvals-and-sandbox',
+            # Structured events let us verify the reviewer ran commands.
+            '--json',
+            '--output-last-message', last_message_path,
+            prompt,
+        ], codex_login=codex_login, model=model)
+        print(codex_cmd)
+
+        if 'CODEX_HOME' not in env:
+            env['CODEX_HOME'] = codex_dir
+
+        exit_code, logs = sb.run(codex_cmd, cwd=cwd, stream=True, env=env)
+        if exit_code != 0:
+            raise CrispError(f'codex-cli failed: exit code {exit_code}')
+
+        cat_exit_code, report_bytes = sb.run(['cat', last_message_path], cwd=cwd, env=env)
+        if cat_exit_code != 0:
+            print(f'warning: failed to read reviewer message: {report_bytes!r}')
+            report_bytes = b''
+
+    ran_commands = _review_ran_commands(logs)
+    return report_bytes.decode('utf-8', errors='replace'), logs, ran_commands
+

--- a/crisp/agent/codex/safety_constraints.md
+++ b/crisp/agent/codex/safety_constraints.md
@@ -31,10 +31,13 @@ The following FFI rules are mandatory:
   the FFI entry point body: an entry point must dispatch to a named
   implementation function, and must not invoke macros that expand to program
   logic or unsafe code.
-- Don't add calls to FFI entry points (`*_ffi` functions). These entry points
-  are only for use from C. When changing a non-FFI function's signature, update
-  all call sites to handle the new signature rather than changing some call
-  sites to call the FFI entry point that still has the old signature.
+- Don't add calls to FFI entry points (`*_ffi` functions), and don't use them
+  as function-pointer values (e.g. don't assign an FFI entry point as a default
+  callback or store it in a function-pointer field -- use the corresponding
+  implementation function instead). These entry points are only for use from C.
+  When changing a non-FFI function's signature, update all call sites to handle
+  the new signature rather than changing some call sites to call the FFI entry
+  point that still has the old signature.
 
 Do not recommend editing tests or original C code to make validation pass. Do
 not recommend new unsafe or unsafe-adjacent implementation code, including raw

--- a/crisp/mvir.py
+++ b/crisp/mvir.py
@@ -709,6 +709,23 @@ class CodexAgentOpNode(Node):
     json_session = property(lambda self: self._metadata['json_session'])
     planning_files = property(lambda self: self._metadata['planning_files'])
 
+class CodexReviewOpNode(Node):
+    KIND = 'codex_review_op'
+    old_code: Metadata[NodeId]
+    new_code: Metadata[NodeId]
+    raw_prompt: Metadata[NodeId]
+    # The reviewer's final message
+    report: Metadata[NodeId]
+    # 'PASS' or 'FAIL'
+    verdict: Metadata[str]
+    # `body` stores the log output
+
+    old_code = property(lambda self: self._metadata['old_code'])
+    new_code = property(lambda self: self._metadata['new_code'])
+    raw_prompt = property(lambda self: self._metadata['raw_prompt'])
+    report = property(lambda self: self._metadata['report'])
+    verdict = property(lambda self: self._metadata['verdict'])
+
 class TestResultNode(Node):
     KIND = 'test_result_node'
     code: Metadata[NodeId]
@@ -930,6 +947,7 @@ NODE_CLASSES = [
     SplitFfiOpNode,
     LlmOpNode,
     CodexAgentOpNode,
+    CodexReviewOpNode,
     TestResultNode,
     CargoCheckJsonAnalysisNode,
     InlineErrorsOpNode,

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -179,7 +179,7 @@ Review the uncommitted changes to the Rust project in `{cargo_dir_path}` ONLY fo
 
 Focus on the FFI entry points touched by the diff.  Read the surrounding code as needed for context; in particular, follow the definition of any macro invoked from an entry point to check for logic hidden in macro expansions.
 
-''' + FFI_ENTRY_POINT_RULES + '''
+{ffi_entry_point_rules}
 
 Report only genuine rule violations present in the changed code; if there are none, report no findings.  For each violation, cite the entry point, the rule violated, and the offending code.
 '''
@@ -1392,7 +1392,9 @@ class Workflow:
         cfg, mvir = self.cfg, self.mvir
         cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
 
-        prompt = AGENT_FFI_REVIEW_PROMPT.format(cargo_dir_path = cargo_dir)
+        prompt = AGENT_FFI_REVIEW_PROMPT.format(
+            cargo_dir_path = cargo_dir,
+            ffi_entry_point_rules = FFI_ENTRY_POINT_RULES)
         report, logs, ran_commands = agent.run_review(cfg, mvir, prompt,
             cfg.models.agent_loop, n_old_code, n_new_code,
             codex_login = self.codex_login)

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -131,7 +131,7 @@ The code contains two kinds of functions: implementation functions and FFI entry
   the FFI entry point body: an entry point must dispatch to a named
   implementation function, and must not invoke macros that expand to program
   logic or unsafe code.
-- Don't add calls to FFI entry points (`*_ffi` functions).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
+- Don't add calls to FFI entry points (`*_ffi` functions), and don't use them as function-pointer values (e.g. don't assign an FFI entry point as a default callback or store it in a function-pointer field -- use the corresponding implementation function instead).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
 '''.strip()
 
 AGENT_PLAN_PROMPT = '''
@@ -207,6 +207,14 @@ cargo check-unsafe2 --manifest-path {cargo_dir_path}/Cargo.toml
 ```
 This will report an error for any unsafe code that was improperly added during your edits. It also reports errors on any newly added "unsafe-adjacent" code, including int-to-pointer casts and arguments or fields of raw pointer type.
 '''
+
+AGENT_FFI_REJECTED_PROMPT = '''
+A previous attempt at this step was rejected because it violated the FFI entry point rules (see `SAFETY_PLAN.md`). The reviewer reported:
+
+{report}
+
+Do not repeat this mistake.
+'''.strip()
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''
 After refactoring, make sure the code still passes the tests.  Run the tests using this script:
@@ -1389,20 +1397,28 @@ class Workflow:
         return n_op
 
     @step
-    def do_ffi_review(self, n_old_code: TreeNode, n_new_code: TreeNode) -> bool:
+    def do_ffi_review(
+        self,
+        n_old_code: TreeNode,
+        n_new_code: TreeNode,
+    ) -> tuple[bool, str | None]:
         """
         Diff-triggered FFI review: if the change touched any FFI entry point,
         have a reviewer agent check it against the FFI entry point rules.
-        Returns `True` if the change is acceptable.
+        Returns `(passed, report)`; `report` is the reviewer's findings when
+        the change is rejected, or `None` if there is no usable report.
         """
         old_defs = self.extract_ffi_defs(n_old_code).defs
         new_defs = self.extract_ffi_defs(n_new_code).defs
         if old_defs == new_defs:
-            return True
+            return True, None
 
         n_op = self.ffi_review_op(n_old_code, n_new_code)
-        print(self.mvir.node(n_op.report).body_str())
-        return n_op.verdict == 'PASS'
+        report = self.mvir.node(n_op.report).body_str()
+        print(report)
+        if n_op.verdict == 'PASS':
+            return True, None
+        return False, report if report.strip() else None
 
     @step
     def agent_safety_no_tests(
@@ -1530,7 +1546,7 @@ class Workflow:
         n_plans: TreeNode,
         prompt_suffix: str | None = None,
         target_goal: AgentTarget = AgentTargetOther(),
-    ) -> tuple[TreeNode | None, TreeNode | None]:
+    ) -> tuple[TreeNode | None, TreeNode | None, str | None]:
         self.fuel.use()
 
         n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
@@ -1540,11 +1556,14 @@ class Workflow:
         # must not break the FFI entry point rules.
         n_op_test = self.test_op(n_new_code, n_test_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
-        if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0 \
-                and self.do_ffi_review(n_code, n_new_code):
-            return n_new_code, n_plans
-        else:
-            return None, None
+        if n_op_test.exit_code != 0 or n_op_unsafe.exit_code != 0:
+            return None, None, None
+        ffi_ok, ffi_report = self.do_ffi_review(n_code, n_new_code)
+        if not ffi_ok:
+            # Surface the reviewer's report so the caller can feed it back
+            # into the next attempt's prompt.
+            return None, None, ffi_report
+        return n_new_code, n_plans, None
 
     @step
     def do_safety_step_agent_sim_no_tests(
@@ -1565,7 +1584,7 @@ class Workflow:
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
             return None, None
-        if not self.do_ffi_review(n_code, n_new_code):
+        if not self.do_ffi_review(n_code, n_new_code)[0]:
             return None, None
 
         # `agent_sim_no_tests` simulates the mode where no tests are

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -189,9 +189,28 @@ Focus on the FFI entry points touched by the diff.  Read the surrounding code as
 Report only genuine rule violations present in the changed code; if there are none, report no findings.  For each violation, cite the entry point, the rule violated, and the offending code.
 '''
 
-# `codex exec review` renders each finding as `- [P1] title -- file:line`;
+# `codex exec review` renders each finding as `- [P1] title — file:line`;
 # a clean review is prose with no such lines.
 AGENT_FFI_REVIEW_FINDING_RE = re.compile(r'^\s*-\s*\[P\d+\]', re.MULTILINE)
+# Same format, capturing the title for `merge_ffi_finding_titles`.
+AGENT_FFI_REVIEW_FINDING_TITLE_RE = re.compile(
+    r'^\s*-\s*\[P\d+\]\s*(.+?)\s*$', re.MULTILINE)
+# Trailing `— file:line` location; stripped because locations go stale.
+AGENT_FFI_REVIEW_FINDING_LOCATION_RE = re.compile(
+    r'\s+(?:—|--)\s+\S+:\d+(?:[-:]\d+)*$')
+
+FFI_SEEN_FINDINGS_CAP = 10
+
+def merge_ffi_finding_titles(seen: list[str], report: str) -> list[str]:
+    """
+    Merge finding titles from a rejecting FFI review `report` into `seen`,
+    deduplicated and bounded to the most recent `FFI_SEEN_FINDINGS_CAP`.
+    """
+    for m in AGENT_FFI_REVIEW_FINDING_TITLE_RE.finditer(report):
+        title = AGENT_FFI_REVIEW_FINDING_LOCATION_RE.sub('', m.group(1)).strip()
+        if title and title not in seen:
+            seen.append(title)
+    return seen[-FFI_SEEN_FINDINGS_CAP:]
 
 AGENT_SAFETY_PROMPT = '''
 Continue the plan from `SAFETY_PLAN.md`.
@@ -214,6 +233,16 @@ A previous attempt at this step was rejected because it violated the FFI entry p
 {report}
 
 Do not repeat this mistake.
+'''.strip()
+
+# Sticky reminder injected into every attempt after the first FFI review
+# rejection in a run, built from harvested reviewer finding titles.
+AGENT_FFI_SEEN_FINDINGS_PROMPT = '''
+Earlier attempts in this run were rejected for violating the FFI entry point rules (see `SAFETY_PLAN.md`). The reviewer's findings included:
+
+{findings}
+
+Do not repeat these mistakes.
 '''.strip()
 
 AGENT_AFTER_REFACTORING_RUN_TESTS = '''

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -124,13 +124,8 @@ The code contains two kinds of functions: implementation functions and FFI entry
 - You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
 - For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
 - Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
-- The FFI entry points should be as minimal as possible, and do as little
-  non-trivial work as necessary. All proper program logic should stay out of
-  the FFI wrappers and instead live in the internal safe Rust code.
-- Don't hide implementation logic in macros. Macro expansions count as part of
-  the FFI entry point body: an entry point must dispatch to a named
-  implementation function, and must not invoke macros that expand to program
-  logic or unsafe code.
+- The FFI entry points should be as minimal as possible, and do as little non-trivial work as necessary. All proper program logic should stay out of the FFI wrappers and instead live in the internal safe Rust code.
+- Don't hide implementation logic in macros. Macro expansions count as part of the FFI entry point body: an entry point must dispatch to a named implementation function, and must not invoke macros that expand to program logic or unsafe code.
 - Don't add calls to FFI entry points (`*_ffi` functions), and don't use them as function-pointer values (e.g. don't assign an FFI entry point as a default callback or store it in a function-pointer field -- use the corresponding implementation function instead).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
 '''.strip()
 

--- a/crisp/workflow.py
+++ b/crisp/workflow.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import functools
 import inspect
 import os
+import re
 import subprocess
 import sys
 import toml
@@ -17,7 +18,7 @@ from .config import Config
 from .error import CrispError
 from .mvir import (
     MVIR, Node, FileNode, TreeNode, CompileCommandsOpNode, TranspileOpNode,
-    LlmOpNode, TestResultNode, FindUnsafeAnalysisNode, SplitFfiOpNode,
+    LlmOpNode, CodexReviewOpNode, TestResultNode, FindUnsafeAnalysisNode, SplitFfiOpNode,
     CargoCheckJsonAnalysisNode, EditOpNode, WorkflowStepInputsNode,
     WorkflowStepNode, SplitOpNode, MergeOpNode, CrateNode, DefNode,
     RelatedDeclsOpNode, FindUnsafe2AnalysisNode, CheckUnsafe2AnalysisNode,
@@ -118,6 +119,21 @@ New signatures:
 {input_files}
 '''
 
+FFI_ENTRY_POINT_RULES = '''
+The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions. Implementation code may be freely refactored to improve safety. For FFI entry points, the following rules apply and must never be changed or broken:
+- You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
+- For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
+- Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
+- The FFI entry points should be as minimal as possible, and do as little
+  non-trivial work as necessary. All proper program logic should stay out of
+  the FFI wrappers and instead live in the internal safe Rust code.
+- Don't hide implementation logic in macros. Macro expansions count as part of
+  the FFI entry point body: an entry point must dispatch to a named
+  implementation function, and must not invoke macros that expand to program
+  logic or unsafe code.
+- Don't add calls to FFI entry points (`*_ffi` functions).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
+'''.strip()
+
 AGENT_PLAN_PROMPT = '''
 Write `SAFETY_PLAN.md`: a migration plan for refactoring the Rust code in `{cargo_dir_path}` to be fully safe without changing its behavior.  The goal state uses safe memory management (`Box`/`Vec`/`Rc`) and safe pointer types (`&T`/`&[T]`) throughout, with all remaining unsafety confined to FFI entry points.
 
@@ -161,19 +177,21 @@ Wait for all agents to finish.  If an agent fails or returns an unusably thin re
 
 # FFI entry point rules (copy verbatim into the plan)
 
-The code contains two kinds of functions: implementation functions and FFI entry points. A function is an FFI entry point if it has the `#[no_mangle]` or `#[export_name]` attribute ("export attributes"). Note that just having `unsafe extern "C"` qualifiers without export attributes does NOT make a function an FFI entry point. All functions without export attributes are implementation functions. Implementation code may be freely refactored to improve safety. For FFI entry points, the following rules apply and must never be changed or broken:
-- You must not change the signature. FFI entry point signatures must remain exactly as-is to ensure ABI compatibility with the current version of the code. Don't remove `unsafe` or `extern "C"` qualifiers from FFI entry points.
-- For struct types that appear only behind a pointer, you may assume the struct is opaque to the user of the library (unless otherwise indicated within the code itself), as is considered best practice in C. This means the struct layout is not part of the ABI, so you may freely change the field types to improve safety.
-- Each FFI entry point should convert the inputs from unsafe types to safe ones (e.g. `*const T` -> `&T`) if needed, dispatch to an implementation function, and convert the results back to unsafe types if needed. Do not add extraneous unsafe code to FFI entry points.
-- Don't add calls to FFI entry points (`*_ffi` functions).  These entry points are only for use from C.  When changing a non-FFI function's signature, you should update all call sites to handle the new signature, rather than changing some call sites to call the FFI entry point that still has the old signature.
-- The FFI entry points should be as minimal as possible, and do as little
-  non-trivial work as necessary. All proper program logic should stay out of
-  the FFI wrappers and instead live in the internal safe Rust code.
-- Don't hide implementation logic in macros. Macro expansions count as part of
-  the FFI entry point body: an entry point must dispatch to a named
-  implementation function, and must not invoke macros that expand to program
-  logic or unsafe code.
+''' + FFI_ENTRY_POINT_RULES + '\n'
+
+AGENT_FFI_REVIEW_PROMPT = '''
+Review the uncommitted changes to the Rust project in `{cargo_dir_path}` ONLY for violations of the FFI entry point rules below.  The changes were made by a refactoring agent whose goal is to make the implementation code fully safe; ordinary code-review concerns (bugs, style, performance) are out of scope unless they violate these rules.
+
+Focus on the FFI entry points touched by the diff.  Read the surrounding code as needed for context; in particular, follow the definition of any macro invoked from an entry point to check for logic hidden in macro expansions.
+
+''' + FFI_ENTRY_POINT_RULES + '''
+
+Report only genuine rule violations present in the changed code; if there are none, report no findings.  For each violation, cite the entry point, the rule violated, and the offending code.
 '''
+
+# `codex exec review` renders each finding as `- [P1] title -- file:line`;
+# a clean review is prose with no such lines.
+AGENT_FFI_REVIEW_FINDING_RE = re.compile(r'^\s*-\s*\[P\d+\]', re.MULTILINE)
 
 AGENT_SAFETY_PROMPT = '''
 Continue the plan from `SAFETY_PLAN.md`.
@@ -1334,6 +1352,59 @@ class Workflow:
         )
 
     @step
+    def ffi_review_op(
+        self,
+        n_old_code: TreeNode,
+        n_new_code: TreeNode,
+    ) -> CodexReviewOpNode:
+        cfg, mvir = self.cfg, self.mvir
+        cargo_dir = cfg.relative_path(cfg.transpile.output_dir)
+
+        prompt = AGENT_FFI_REVIEW_PROMPT.format(cargo_dir_path = cargo_dir)
+        report, logs, ran_commands = agent.run_review(cfg, mvir, prompt,
+            cfg.models.agent_loop, n_old_code, n_new_code,
+            codex_login = self.codex_login)
+
+        if report.strip() == '':
+            # Fail closed on a missing report.
+            print('warning: FFI review returned an empty report')
+            passed = False
+        elif not ran_commands:
+            # Fail closed when the reviewer never successfully ran a command:
+            # it cannot have inspected the diff, whatever the report says.
+            print('warning: FFI review ran no commands; ignoring its report')
+            passed = False
+        else:
+            passed = AGENT_FFI_REVIEW_FINDING_RE.search(report) is None
+
+        n_op = CodexReviewOpNode.new(mvir,
+            old_code = n_old_code.node_id(),
+            new_code = n_new_code.node_id(),
+            raw_prompt = FileNode.new(mvir, prompt).node_id(),
+            report = FileNode.new(mvir, report).node_id(),
+            verdict = 'PASS' if passed else 'FAIL',
+            body = logs,
+        )
+        mvir.set_tag('op_history', n_op.node_id(), n_op.kind)
+        return n_op
+
+    @step
+    def do_ffi_review(self, n_old_code: TreeNode, n_new_code: TreeNode) -> bool:
+        """
+        Diff-triggered FFI review: if the change touched any FFI entry point,
+        have a reviewer agent check it against the FFI entry point rules.
+        Returns `True` if the change is acceptable.
+        """
+        old_defs = self.extract_ffi_defs(n_old_code).defs
+        new_defs = self.extract_ffi_defs(n_new_code).defs
+        if old_defs == new_defs:
+            return True
+
+        n_op = self.ffi_review_op(n_old_code, n_new_code)
+        print(self.mvir.node(n_op.report).body_str())
+        return n_op.verdict == 'PASS'
+
+    @step
     def agent_safety_no_tests(
         self,
         n_code: TreeNode,
@@ -1465,10 +1536,12 @@ class Workflow:
         n_new_code, n_plans = self.agent_safety(n_code, n_test_code, n_plans,
             prompt_suffix = prompt_suffix,
             target_goal = target_goal)
-        # The change must pass tests, and must not regress any unsafe count.
+        # The change must pass tests, must not regress any unsafe count, and
+        # must not break the FFI entry point rules.
         n_op_test = self.test_op(n_new_code, n_test_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
-        if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0:
+        if n_op_test.exit_code == 0 and n_op_unsafe.exit_code == 0 \
+                and self.do_ffi_review(n_code, n_new_code):
             return n_new_code, n_plans
         else:
             return None, None
@@ -1491,6 +1564,8 @@ class Workflow:
         n_op_check = self.cargo_check_json_op(n_new_code)
         n_op_unsafe = self.compare_unsafe2_op(n_code, n_new_code)
         if not (n_op_check.passed and n_op_unsafe.exit_code == 0):
+            return None, None
+        if not self.do_ffi_review(n_code, n_new_code):
             return None, None
 
         # `agent_sim_no_tests` simulates the mode where no tests are

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,36 @@
+import unittest
+
+from crisp.workflow import FFI_SEEN_FINDINGS_CAP, merge_ffi_finding_titles
+
+
+# Finding lines as rendered by `codex exec review` (from a real zlib run).
+REPORT = '''
+The diff removes `unsafe` from several exported entry points.
+
+- [P1] Restore `unsafe` on `gz_intmax_ffi` — /root/work/translated_rust/src/gzlib.rs:1425-1425
+- [P1] Restore `unsafe` on `zlibVersion_ffi` — /root/work/translated_rust/src/zutil.rs:27-27
+- [P2] Wrapper contains validation logic — /root/work/translated_rust/src/gzlib.rs:100-120
+'''
+
+
+class MergeFfiFindingTitlesTest(unittest.TestCase):
+    def test_extracts_titles_without_locations(self):
+        self.assertEqual(merge_ffi_finding_titles([], REPORT), [
+            'Restore `unsafe` on `gz_intmax_ffi`',
+            'Restore `unsafe` on `zlibVersion_ffi`',
+            'Wrapper contains validation logic',
+        ])
+
+    def test_merge_deduplicates(self):
+        seen = merge_ffi_finding_titles([], REPORT)
+        self.assertEqual(merge_ffi_finding_titles(list(seen), REPORT), seen)
+
+    def test_bounded_keeps_most_recent(self):
+        report = '\n'.join(
+            f'- [P1] finding {i} — src/a.rs:{i}-{i}' for i in range(20))
+        seen = merge_ffi_finding_titles([], report)
+        self.assertEqual(len(seen), FFI_SEEN_FINDINGS_CAP)
+        self.assertEqual(seen[-1], 'finding 19')
+
+    def test_clean_report_adds_nothing(self):
+        self.assertEqual(merge_ffi_finding_titles([], 'No violations found.'), [])


### PR DESCRIPTION
Stacked on #160. Adds a review gate for FFI entry point edits, feeds rejections back into the next safety attempt, and reminds the safety agent of findings already seen this run.