### PR TITLE
docker: adjust timeout

### DIFF
--- a/crisp/sandbox/docker.py
+++ b/crisp/sandbox/docker.py
@@ -38,7 +38,8 @@ class WorkContainer:
 
     def start(self):
         self.container = self.client.containers.run(
-                self.image, ('sleep', '1000'), detach=True, remove=True)
+            # `sleep` is PID 1; its duration caps the lifetime of the container.
+            self.image, ('sleep', '1800'), detach=True, remove=True)
 
     def stop(self):
         if self.container is not None:


### PR DESCRIPTION
We hit a timeout during lifting of `zlib` using codex 0.145/gpt-5.6-terra so allow 30m of container uptime to allow longer running agent sessions.