### PR TITLE
crisp: enable a couple refactor passes to shorten code

### DIFF
--- a/crisp/__main__.py
+++ b/crisp/__main__.py
@@ -245,7 +245,7 @@ def do_main(args, cfg):
         n_code = w.transpile(
             n_c_code,
             src_loc_annotations=True,
-            refactor_transforms=("rename_unnamed", "reorganize_definitions"),
+            refactor_transforms=("rename_unnamed", "reorganize_definitions", "remove_redundant_casts", "remove_redundant_let_types"),
         )
     if n_code is None:
         n_code = w.transpile(n_c_code, src_loc_annotations=True, hayroll=True)


### PR DESCRIPTION
Other passes might be also worthwhile, but these ones in particular seem like they should result in smaller code and plausibly less token usage when reading+rewriting this code via LLM subsequently.